### PR TITLE
chore(repo): ignore local .claude directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,10 @@
 __pycache__/
 .pytest_cache/
 .venv/
+
+# Local tooling (Claude Code, etc.)
+.claude/
+
 node_modules/
 dist/
 build/


### PR DESCRIPTION
## Cambios
- Añade `.claude/` al `.gitignore` para no versionar ajustes locales de Claude.

## Contexto
La carpeta local de Claude ya no se usa; el remoto canónico del repo es **CryptarchHQ/Cryptarch**.

Made with [Cursor](https://cursor.com)