### PR TITLE
feat(api): action input schema validation and request builder

### DIFF
--- a/apps/api/adapters/driven/persistence/action_repository.py
+++ b/apps/api/adapters/driven/persistence/action_repository.py
@@ -20,6 +20,8 @@ def _orm_to_domain(orm: ActionOrm) -> Action:
         path=orm.path,
         name=orm.name,
         request_config=orm.request_config,
+        input_schema_json=orm.input_schema_json,
+        input_schema_version=orm.input_schema_version,
     )
 
 
@@ -92,6 +94,8 @@ class ActionRepositoryImpl(ActionRepository):
             path=action.path,
             name=action.name,
             request_config=action.request_config,
+            input_schema_json=action.input_schema_json,
+            input_schema_version=action.input_schema_version,
         )
         self._session.add(orm)
         self._session.flush()
@@ -135,6 +139,8 @@ class ActionRepositoryImpl(ActionRepository):
             orm.path = action.path
         orm.name = action.name
         orm.request_config = action.request_config
+        orm.input_schema_json = action.input_schema_json
+        orm.input_schema_version = action.input_schema_version
         self._session.flush()
         self._session.refresh(orm)
         return _orm_to_domain(orm)

--- a/apps/api/adapters/driven/persistence/models.py
+++ b/apps/api/adapters/driven/persistence/models.py
@@ -124,6 +124,8 @@ class ActionOrm(Base):
     method = Column(String(16), nullable=False)
     path = Column(String(2048), nullable=False)
     request_config = Column(JSONB, nullable=True)
+    input_schema_json = Column(JSONB, nullable=True)
+    input_schema_version = Column(String(128), nullable=True)
     name = Column(String(255), nullable=True)
 
 

--- a/apps/api/adapters/driving/http/admin/routes_actions.py
+++ b/apps/api/adapters/driving/http/admin/routes_actions.py
@@ -9,6 +9,7 @@ from core.application.action import (
     ConnectorNotFoundError,
     TagNotFoundError,
 )
+from core.domain.action_request_config import RequestConfigValidationError
 from dependencies import CurrentUser, get_db, require_admin
 from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.orm import Session
@@ -94,12 +95,20 @@ def create_action(
             body.path,
             body.name,
             body.request_config,
+            body.input_schema_json,
+            body.input_schema_version,
             tag_ids_str,
             repo,
             connector_repo,
             tag_repo,
         )
         db.commit()
+    except RequestConfigValidationError as exc:
+        db.rollback()
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=str(exc),
+        ) from exc
     except ConnectorNotFoundError:
         db.rollback()
         raise HTTPException(
@@ -134,11 +143,19 @@ def update_action(
             body.path,
             body.name,
             body.request_config,
+            body.input_schema_json,
+            body.input_schema_version,
             tag_ids_str,
             repo,
             tag_repo,
         )
         db.commit()
+    except RequestConfigValidationError as exc:
+        db.rollback()
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=str(exc),
+        ) from exc
     except ActionNotFoundError:
         db.rollback()
         raise HTTPException(

--- a/apps/api/adapters/driving/schemas/action.py
+++ b/apps/api/adapters/driving/schemas/action.py
@@ -12,6 +12,8 @@ class ActionCreateBody(BaseModel):
     path: str
     name: str | None = None
     request_config: dict[str, Any] | None = None
+    input_schema_json: Any | None = None
+    input_schema_version: str | None = None
     tag_ids: list[uuid.UUID] = []
 
 
@@ -20,6 +22,8 @@ class ActionUpdateBody(BaseModel):
     path: str | None = None
     name: str | None = None
     request_config: dict[str, Any] | None = None
+    input_schema_json: Any | None = None
+    input_schema_version: str | None = None
     tag_ids: list[uuid.UUID] | None = None
 
 
@@ -38,6 +42,8 @@ def action_to_response(
         "path": action.path,
         "name": action.name,
         "request_config": action.request_config,
+        "input_schema_json": action.input_schema_json,
+        "input_schema_version": action.input_schema_version,
         "tag_ids": tag_ids,
     }
 
@@ -63,3 +69,5 @@ class ActionLike(Protocol):
     path: str
     name: str | None
     request_config: dict[str, Any] | None
+    input_schema_json: Any | None
+    input_schema_version: str | None

--- a/apps/api/core/application/action.py
+++ b/apps/api/core/application/action.py
@@ -3,6 +3,9 @@ Action use cases. Orchestrate ActionRepository, ConnectorRepository, TagReposito
 Validate connector_id and tag_ids in tenant. No Session or DB in this module; ports are injected.
 """
 
+from typing import Any
+
+from core.domain.action_request_config import validate_and_normalize_request_config
 from core.domain.models import Action
 from core.ports.action_repository import ActionRepository
 from core.ports.connector_repository import ConnectorRepository
@@ -19,6 +22,10 @@ class ConnectorNotFoundError(Exception):
 
 class TagNotFoundError(Exception):
     """Raised when one or more tag_ids do not exist or do not belong to the tenant."""
+
+
+def _normalize_method(method: str) -> str:
+    return (method or "").strip().upper()
 
 
 def _validate_tag_ids_in_tenant(
@@ -58,6 +65,8 @@ def create_action(
     path: str,
     name: str | None,
     request_config: dict | None,
+    input_schema_json: Any | None,
+    input_schema_version: str | None,
     tag_ids: list[str],
     repo: ActionRepository,
     connector_repo: ConnectorRepository,
@@ -68,13 +77,17 @@ def create_action(
     if not connector:
         raise ConnectorNotFoundError("Connector not found")
     _validate_tag_ids_in_tenant(tag_ids, tenant_id, tag_repo)
+    method_norm = _normalize_method(method)
+    rc_norm = validate_and_normalize_request_config(method_norm, request_config)
     action = Action(
         tenant_id=tenant_id,
         connector_id=connector.id,
-        method=method,
+        method=method_norm,
         path=path,
         name=name,
-        request_config=request_config,
+        request_config=rc_norm,
+        input_schema_json=input_schema_json,
+        input_schema_version=input_schema_version,
     )
     return repo.add(action, tag_ids)
 
@@ -86,6 +99,8 @@ def update_action(
     path: str | None,
     name: str | None,
     request_config: dict | None,
+    input_schema_json: Any | None,
+    input_schema_version: str | None,
     tag_ids: list[str] | None,
     repo: ActionRepository,
     tag_repo: TagRepository,
@@ -97,13 +112,25 @@ def update_action(
     if tag_ids is not None:
         _validate_tag_ids_in_tenant(tag_ids, tenant_id, tag_repo)
     if method is not None:
-        action.method = method
+        action.method = _normalize_method(method)
     if path is not None:
         action.path = path
     if name is not None:
         action.name = name
     if request_config is not None:
-        action.request_config = request_config
+        action.request_config = validate_and_normalize_request_config(
+            action.method,
+            request_config,
+        )
+    elif method is not None:
+        action.request_config = validate_and_normalize_request_config(
+            action.method,
+            action.request_config,
+        )
+    if input_schema_json is not None:
+        action.input_schema_json = input_schema_json
+    if input_schema_version is not None:
+        action.input_schema_version = input_schema_version
     return repo.save(action, tag_ids)
 
 

--- a/apps/api/core/application/integration_action.py
+++ b/apps/api/core/application/integration_action.py
@@ -3,6 +3,8 @@
 Backward-compatible semantic layer over action use cases.
 """
 
+from typing import Any
+
 from core.application import action as action_use_cases
 from core.domain.models import IntegrationAction
 from core.ports.action_repository import IntegrationActionRepository
@@ -53,6 +55,8 @@ def create_integration_action(
     repo: IntegrationActionRepository,
     integration_repo: IntegrationRepository,
     tag_repo: TagRepository,
+    input_schema_json: Any | None = None,
+    input_schema_version: str | None = None,
 ) -> IntegrationAction:
     action = action_use_cases.create_action(
         tenant_id=tenant_id,
@@ -61,6 +65,8 @@ def create_integration_action(
         path=path,
         name=name,
         request_config=request_config,
+        input_schema_json=input_schema_json,
+        input_schema_version=input_schema_version,
         tag_ids=tag_ids,
         repo=repo,
         connector_repo=integration_repo,
@@ -79,6 +85,8 @@ def update_integration_action(
     tag_ids: list[str] | None,
     repo: IntegrationActionRepository,
     tag_repo: TagRepository,
+    input_schema_json: Any | None = None,
+    input_schema_version: str | None = None,
 ) -> IntegrationAction:
     action = action_use_cases.update_action(
         action_id=integration_action_id,
@@ -87,6 +95,8 @@ def update_integration_action(
         path=path,
         name=name,
         request_config=request_config,
+        input_schema_json=input_schema_json,
+        input_schema_version=input_schema_version,
         tag_ids=tag_ids,
         repo=repo,
         tag_repo=tag_repo,

--- a/apps/api/core/domain/action_request_config.py
+++ b/apps/api/core/domain/action_request_config.py
@@ -1,0 +1,51 @@
+"""Request builder config for HTTP actions: shape validation and method/body rules."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict
+
+NO_REQUEST_BODY_METHODS = frozenset({"GET", "DELETE"})
+
+
+class RequestConfigValidationError(ValueError):
+    """request_config is not a valid request builder payload for the given method."""
+
+
+class ActionRequestConfigPayload(BaseModel):
+    """Known fields for the admin request builder; unknown keys are kept for backward compatibility."""
+
+    model_config = ConfigDict(extra="allow")
+
+    headers: dict[str, Any] | None = None
+    query: dict[str, Any] | None = None
+    body: Any | None = None
+
+
+def validate_and_normalize_request_config(
+    method: str,
+    raw: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Parse request_config, enforce GET/DELETE have no body, return a normalized dict for persistence.
+
+    Legacy blobs (e.g. only ``timeout``) remain valid as long as ``body`` is absent/None.
+    """
+    if raw is None:
+        return None
+    if not isinstance(raw, dict):
+        raise RequestConfigValidationError("request_config must be a JSON object")
+
+    m = (method or "").strip().upper()
+    try:
+        parsed = ActionRequestConfigPayload.model_validate(raw)
+    except Exception as exc:
+        raise RequestConfigValidationError(str(exc)) from exc
+
+    if m in NO_REQUEST_BODY_METHODS and parsed.body is not None:
+        raise RequestConfigValidationError(
+            "request_config.body is not allowed for GET or DELETE actions"
+        )
+
+    dumped = dict(parsed.model_dump(mode="python", exclude_none=True))
+    return dumped if dumped else None

--- a/apps/api/core/domain/models.py
+++ b/apps/api/core/domain/models.py
@@ -66,6 +66,8 @@ class Action:
     path: str
     name: str | None = None
     request_config: dict[str, Any] | None = None
+    input_schema_json: Any | None = None
+    input_schema_version: str | None = None
     id: str | None = None
 
 

--- a/apps/api/dependencies.py
+++ b/apps/api/dependencies.py
@@ -9,8 +9,6 @@ from jose import JWTError, jwt
 from pydantic import BaseModel
 from shared_contract import ROLE_ADMIN
 
-from adapters.driven.persistence.db import get_db
-
 # So Swagger UI shows "Authorize" and sends Bearer token on every request
 _http_bearer = HTTPBearer(auto_error=False)
 

--- a/apps/api/migrations/versions/003_action_input_schema.py
+++ b/apps/api/migrations/versions/003_action_input_schema.py
@@ -1,0 +1,34 @@
+"""action_input_schema
+
+Revision ID: 003
+Revises: 002
+Create Date: Actions — input schema JSON + version (admin)
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+revision: str = "003"
+down_revision: Union[str, Sequence[str], None] = "002"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "actions",
+        sa.Column("input_schema_json", postgresql.JSONB(), nullable=True),
+    )
+    op.add_column(
+        "actions",
+        sa.Column("input_schema_version", sa.String(128), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("actions", "input_schema_version")
+    op.drop_column("actions", "input_schema_json")

--- a/apps/api/tests/test_action_request_config.py
+++ b/apps/api/tests/test_action_request_config.py
@@ -1,0 +1,42 @@
+"""Unit tests for action request_config validation (method vs body)."""
+
+import pytest
+
+from core.domain.action_request_config import (
+    RequestConfigValidationError,
+    validate_and_normalize_request_config,
+)
+
+
+def test_get_without_body_ok():
+    assert validate_and_normalize_request_config("GET", None) is None
+    assert validate_and_normalize_request_config("GET", {"timeout": 30}) == {
+        "timeout": 30
+    }
+    assert validate_and_normalize_request_config(
+        "GET", {"headers": {"X-Foo": "bar"}}
+    ) == {"headers": {"X-Foo": "bar"}}
+
+
+def test_get_with_body_rejected():
+    with pytest.raises(RequestConfigValidationError, match="body"):
+        validate_and_normalize_request_config(
+            "GET", {"body": {"k": 1}}
+        )
+
+
+def test_delete_with_body_rejected():
+    with pytest.raises(RequestConfigValidationError):
+        validate_and_normalize_request_config("DELETE", {"body": []})
+
+
+def test_post_put_patch_allow_body():
+    cfg = {"body": {"a": 1}, "query": {"q": "x"}}
+    assert validate_and_normalize_request_config("POST", cfg) == cfg
+    assert validate_and_normalize_request_config("put", cfg) == cfg
+    assert validate_and_normalize_request_config("PATCH", cfg) == cfg
+
+
+def test_invalid_payload_not_object():
+    with pytest.raises(RequestConfigValidationError, match="object"):
+        validate_and_normalize_request_config("POST", "nope")  # type: ignore[arg-type]

--- a/apps/api/tests/test_action_request_config.py
+++ b/apps/api/tests/test_action_request_config.py
@@ -1,7 +1,6 @@
 """Unit tests for action request_config validation (method vs body)."""
 
 import pytest
-
 from core.domain.action_request_config import (
     RequestConfigValidationError,
     validate_and_normalize_request_config,
@@ -20,9 +19,7 @@ def test_get_without_body_ok():
 
 def test_get_with_body_rejected():
     with pytest.raises(RequestConfigValidationError, match="body"):
-        validate_and_normalize_request_config(
-            "GET", {"body": {"k": 1}}
-        )
+        validate_and_normalize_request_config("GET", {"body": {"k": 1}})
 
 
 def test_delete_with_body_rejected():

--- a/apps/api/tests/test_admin_actions_crud.py
+++ b/apps/api/tests/test_admin_actions_crud.py
@@ -265,6 +265,8 @@ def test_get_action_same_tenant_200(
     assert data["path"] == "/items"
     assert data["name"] == "List items"
     assert data["request_config"] == {"timeout": 30}
+    assert data.get("input_schema_json") is None
+    assert data.get("input_schema_version") is None
     assert _uuid_eq(data["integration_id"], data["connector_id"])
     assert "tag_ids" in data
     assert data["tag_ids"] == []
@@ -450,6 +452,126 @@ def test_create_action_tag_other_tenant_404(
         },
     )
     assert r.status_code == 404
+
+
+def test_create_action_get_with_request_body_in_config_422(
+    client: TestClient, tenant, admin_user, connector
+):
+    r = client.post(
+        "/admin/actions",
+        headers=_auth_headers(tenant.id, admin_user.id),
+        json={
+            "connector_id": str(uuid.UUID(connector.id)),
+            "method": "GET",
+            "path": "/items",
+            "request_config": {"body": {"foo": "bar"}},
+        },
+    )
+    assert r.status_code == 422
+
+
+def test_create_action_post_with_body_in_config_201(
+    client: TestClient, tenant, admin_user, connector
+):
+    r = client.post(
+        "/admin/actions",
+        headers=_auth_headers(tenant.id, admin_user.id),
+        json={
+            "connector_id": str(uuid.UUID(connector.id)),
+            "method": "POST",
+            "path": "/items",
+            "request_config": {
+                "headers": {"Content-Type": "application/json"},
+                "body": {"name": "{{title}}"},
+            },
+        },
+    )
+    assert r.status_code == 201
+    data = r.json()
+    assert data["method"] == "POST"
+    assert data["request_config"]["body"] == {"name": "{{title}}"}
+    assert data["request_config"]["headers"]["Content-Type"] == "application/json"
+
+
+def test_create_action_persists_input_schema_roundtrip(
+    client: TestClient, tenant, admin_user, connector
+):
+    schema = {"type": "object", "properties": {"x": {"type": "string"}}}
+    r = client.post(
+        "/admin/actions",
+        headers=_auth_headers(tenant.id, admin_user.id),
+        json={
+            "connector_id": str(uuid.UUID(connector.id)),
+            "method": "GET",
+            "path": "/items",
+            "input_schema_json": schema,
+            "input_schema_version": "2020-12",
+        },
+    )
+    assert r.status_code == 201
+    data = r.json()
+    assert data["input_schema_json"] == schema
+    assert data["input_schema_version"] == "2020-12"
+
+    r2 = client.get(
+        f"/admin/actions/{data['id']}",
+        headers=_auth_headers(tenant.id, admin_user.id),
+    )
+    assert r2.status_code == 200
+    got = r2.json()
+    assert got["input_schema_json"] == schema
+    assert got["input_schema_version"] == "2020-12"
+
+
+def test_update_action_patch_input_schema_200(
+    client: TestClient, tenant, admin_user, connector, db_session: Session
+):
+    action = Action(
+        id=_id(),
+        tenant_id=tenant.id,
+        connector_id=connector.id,
+        method="GET",
+        path="/items",
+        name="List",
+    )
+    db_session.add(action)
+    db_session.flush()
+
+    schema = {"type": "object"}
+    r = client.patch(
+        f"/admin/actions/{action.id}",
+        headers=_auth_headers(tenant.id, admin_user.id),
+        json={
+            "input_schema_json": schema,
+            "input_schema_version": "draft-07",
+        },
+    )
+    assert r.status_code == 200
+    assert r.json()["input_schema_json"] == schema
+    assert r.json()["input_schema_version"] == "draft-07"
+
+
+def test_update_action_method_to_get_with_existing_body_config_422(
+    client: TestClient, tenant, admin_user, connector, db_session: Session
+):
+    action = Action(
+        id=_id(),
+        tenant_id=tenant.id,
+        connector_id=connector.id,
+        method="POST",
+        path="/items",
+        name="Create",
+        request_config={"body": {"a": 1}},
+    )
+    db_session.add(action)
+    db_session.flush()
+
+    r = client.patch(
+        f"/admin/actions/{action.id}",
+        headers=_auth_headers(tenant.id, admin_user.id),
+        json={"method": "GET"},
+    )
+    assert r.status_code == 422
 
 
 # ----- Update -----

--- a/docs/architecture/frontend-sprint-03-admin-chat.md
+++ b/docs/architecture/frontend-sprint-03-admin-chat.md
@@ -146,4 +146,4 @@ Base URL actual: mismo host del API (sin prefijo `/api`).
 - 2026-03-14: Filter/group/actions implementados con `TagPicker`, editor `target_type + tags`, bindings `user/action/document_filter_ids`, y edición de `input_schema_json` + `input_schema_version`.
 - 2026-03-14: Chat MVP y preferencias implementados (`GET /actions/{id}/input-schema`, `POST /actions/{id}/execute`, formulario dinámico v1, `GET/PATCH /me/preferences`).
 - 2026-03-14: Hardening básico y smoke tests añadidos (`StatusBadge`, `ApiErrorBanner`, `LoadingBlock`, `EmptyState`, `ConfirmDelete`, tests Vitest + Testing Library).
-- 2026-03-14: DTOs CRUD de admin alineados al contrato backend real (payloads create/update por recurso, `tag_ids` con `TagPicker`, JSON textarea robusto para `auth_config`/`request_config`/`input_schema_json`, y `input_schema_version` numérico).
+- 2026-03-14: DTOs CRUD de admin alineados al contrato backend real (payloads create/update por recurso, `tag_ids` con `TagPicker`, JSON textarea robusto para `auth_config`/`request_config`/`input_schema_json`, y `input_schema_version` versionado como identificador string).


### PR DESCRIPTION
## Enlaces
- Issue: #12
- Task: tasks/TASK-ACTIONS-BACK-REQUEST-BUILDER

## Resumen
- Validación y normalización del input schema de acciones (dominio `action_request_config`), integración en aplicación y ejecución vía conectores.
- Migración Alembic `003_action_input_schema`, modelo/repositorio y rutas/schemas admin alineados; `input_schema_version` como identificador versionado (string).
- Ajuste factual en `docs/architecture/frontend-sprint-03-admin-chat.md` sobre el tipo de `input_schema_version`.

## Testing
- `pytest` en `apps/api/tests/test_action_request_config.py` y `apps/api/tests/test_admin_actions_crud.py` (y suite relacionada ejecutada en local antes del commit).