### PR TITLE
feat(web): chat workspace with allowed actions list and dynamic form

### DIFF
--- a/apps/web/src/modules/admin/adminHelpers.js
+++ b/apps/web/src/modules/admin/adminHelpers.js
@@ -151,6 +151,19 @@ export function chatFieldsFromInputSchemaJson(raw) {
   });
 }
 
+/** Valor inicial del payload de chat para un campo normalizado. */
+export function initialValueForField(field) {
+  if (field?.type === "boolean") return false;
+  return "";
+}
+
+/** Convierte el valor del formulario al tipo esperado en el payload de ejecución. */
+export function castPayloadValue(field, value) {
+  if (field?.type === "number") return Number(value);
+  if (field?.type === "boolean") return Boolean(value);
+  return value;
+}
+
 export function extractFileName(path) {
   if (!path) return "Documento";
   const normalized = String(path).replaceAll("\\", "/");

--- a/apps/web/src/modules/chat/ActionExecutionResult.jsx
+++ b/apps/web/src/modules/chat/ActionExecutionResult.jsx
@@ -1,0 +1,99 @@
+import { useMemo, useState } from "react";
+import { toJsonText } from "../admin/adminHelpers";
+
+function isStructuredResult(value) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  return (
+    Object.prototype.hasOwnProperty.call(value, "status") ||
+    Object.prototype.hasOwnProperty.call(value, "message") ||
+    Object.prototype.hasOwnProperty.call(value, "data")
+  );
+}
+
+export function ActionExecutionResult({ result }) {
+  const [showRaw, setShowRaw] = useState(false);
+  const structured = useMemo(() => isStructuredResult(result), [result]);
+
+  if (result === null || result === undefined) return null;
+
+  const jsonText = toJsonText(result);
+
+  return (
+    <div className="stack dense">
+      <div className="row spread">
+        <h3 style={{ margin: 0 }}>Resultado</h3>
+        <label className="check-row text-sm">
+          <input
+            type="checkbox"
+            checked={showRaw}
+            onChange={(e) => setShowRaw(e.target.checked)}
+          />
+          Ver JSON
+        </label>
+      </div>
+
+      {showRaw ? (
+        <pre
+          className="chat-result-json"
+          style={{
+            margin: 0,
+            padding: 12,
+            background: "#f4f6fb",
+            borderRadius: 8,
+            overflow: "auto",
+            fontSize: 13,
+          }}
+        >
+          {jsonText}
+        </pre>
+      ) : structured ? (
+        <div className="stack dense chat-result-structured">
+          {Object.prototype.hasOwnProperty.call(result, "status") ? (
+            <div>
+              <strong className="text-sm">Estado</strong>
+              <div>{String(result.status)}</div>
+            </div>
+          ) : null}
+          {Object.prototype.hasOwnProperty.call(result, "message") ? (
+            <div>
+              <strong className="text-sm">Mensaje</strong>
+              <div>{String(result.message)}</div>
+            </div>
+          ) : null}
+          {Object.prototype.hasOwnProperty.call(result, "data") ? (
+            <div>
+              <strong className="text-sm">Datos</strong>
+              <pre
+                style={{
+                  margin: "6px 0 0",
+                  padding: 10,
+                  background: "#f4f6fb",
+                  borderRadius: 8,
+                  overflow: "auto",
+                  fontSize: 13,
+                }}
+              >
+                {typeof result.data === "string"
+                  ? result.data
+                  : toJsonText(result.data)}
+              </pre>
+            </div>
+          ) : null}
+        </div>
+      ) : (
+        <pre
+          style={{
+            margin: 0,
+            padding: 12,
+            background: "#f4f6fb",
+            borderRadius: 8,
+            overflow: "auto",
+            fontSize: 13,
+          }}
+        >
+          {jsonText}
+        </pre>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/modules/chat/AllowedActionsList.jsx
+++ b/apps/web/src/modules/chat/AllowedActionsList.jsx
@@ -1,0 +1,39 @@
+function actionSubtitle(action) {
+  const desc =
+    typeof action?.input_schema_json?.description === "string"
+      ? action.input_schema_json.description.trim()
+      : "";
+  if (desc) return desc;
+  return null;
+}
+
+export function AllowedActionsList({ actions, selectedId, onSelect }) {
+  return (
+    <div className="connector-list" role="list">
+      {actions.map((action) => {
+        const id = action.id;
+        const selected = id === selectedId;
+        const subtitle = actionSubtitle(action);
+        return (
+          <button
+            key={id}
+            type="button"
+            role="listitem"
+            className={`connector-card panel subtle${selected ? " selected" : ""}`}
+            onClick={() => onSelect(action)}
+            style={{ cursor: "pointer", border: "1px solid #e5e7ef" }}
+          >
+            <strong style={{ fontSize: 14 }}>
+              {action.name?.trim() || "Acción sin nombre"}
+            </strong>
+            {subtitle ? (
+              <span className="text-sm muted" style={{ lineHeight: 1.35 }}>
+                {subtitle}
+              </span>
+            ) : null}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/web/src/modules/chat/AllowedActionsList.jsx
+++ b/apps/web/src/modules/chat/AllowedActionsList.jsx
@@ -1,10 +1,19 @@
-function actionSubtitle(action) {
+function formatActionMeta(action) {
+  const method =
+    typeof action?.method === "string"
+      ? action.method.trim().toUpperCase()
+      : "";
+  const pathStr = typeof action?.path === "string" ? action.path.trim() : "";
+  if (!method && !pathStr) return null;
+  return [method, pathStr].filter(Boolean).join(" ");
+}
+
+function schemaDescription(action) {
   const desc =
     typeof action?.input_schema_json?.description === "string"
       ? action.input_schema_json.description.trim()
       : "";
-  if (desc) return desc;
-  return null;
+  return desc || null;
 }
 
 export function AllowedActionsList({ actions, selectedId, onSelect }) {
@@ -13,7 +22,8 @@ export function AllowedActionsList({ actions, selectedId, onSelect }) {
       {actions.map((action) => {
         const id = action.id;
         const selected = id === selectedId;
-        const subtitle = actionSubtitle(action);
+        const meta = formatActionMeta(action);
+        const description = schemaDescription(action);
         return (
           <button
             key={id}
@@ -26,9 +36,10 @@ export function AllowedActionsList({ actions, selectedId, onSelect }) {
             <strong style={{ fontSize: 14 }}>
               {action.name?.trim() || "Acción sin nombre"}
             </strong>
-            {subtitle ? (
+            {meta ? <span className="allowed-action-meta">{meta}</span> : null}
+            {description ? (
               <span className="text-sm muted" style={{ lineHeight: 1.35 }}>
-                {subtitle}
+                {description}
               </span>
             ) : null}
           </button>

--- a/apps/web/src/modules/chat/ChatPage.jsx
+++ b/apps/web/src/modules/chat/ChatPage.jsx
@@ -1,169 +1,80 @@
-import { useMemo, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { useAuth } from "../../app/AuthProvider";
 import { api } from "../../shared/apiClient";
-import { ApiErrorBanner, LoadingBlock } from "../../shared/ui";
+import { ApiErrorBanner, EmptyState, LoadingBlock } from "../../shared/ui";
 import { PreferencesPanel } from "../preferences/PreferencesPanel";
-import { chatFieldsFromInputSchemaJson } from "../admin/adminHelpers";
-
-function initialValueByType(type) {
-  if (type === "boolean") return false;
-  return "";
-}
-
-function castValueByType(type, value) {
-  if (type === "number") return Number(value);
-  if (type === "boolean") return Boolean(value);
-  return value;
-}
-
-function FieldRenderer({ field, value, onChange }) {
-  const options = field.options || [];
-  switch (field.type) {
-    case "textarea":
-      return (
-        <textarea
-          rows={4}
-          value={value}
-          onChange={(e) => onChange(e.target.value)}
-        />
-      );
-    case "number":
-      return (
-        <input
-          type="number"
-          value={value}
-          onChange={(e) => onChange(e.target.value)}
-        />
-      );
-    case "boolean":
-      return (
-        <input
-          type="checkbox"
-          checked={Boolean(value)}
-          onChange={(e) => onChange(e.target.checked)}
-        />
-      );
-    case "select":
-      return (
-        <select value={value} onChange={(e) => onChange(e.target.value)}>
-          <option value="">--</option>
-          {options.map((opt) => (
-            <option
-              key={String(opt.value ?? opt)}
-              value={String(opt.value ?? opt)}
-            >
-              {opt.label ?? opt.value ?? opt}
-            </option>
-          ))}
-        </select>
-      );
-    case "radio":
-      return (
-        <div className="row">
-          {options.map((opt) => {
-            const optionValue = String(opt.value ?? opt);
-            return (
-              <label key={optionValue}>
-                <input
-                  type="radio"
-                  name={field.name}
-                  checked={String(value) === optionValue}
-                  onChange={() => onChange(optionValue)}
-                />
-                {opt.label ?? opt.value ?? opt}
-              </label>
-            );
-          })}
-        </div>
-      );
-    case "date":
-      return (
-        <input
-          type="date"
-          value={value}
-          onChange={(e) => onChange(e.target.value)}
-        />
-      );
-    default:
-      return (
-        <input
-          type="text"
-          value={value}
-          onChange={(e) => onChange(e.target.value)}
-        />
-      );
-  }
-}
+import { ActionExecutionResult } from "./ActionExecutionResult";
+import { AllowedActionsList } from "./AllowedActionsList";
+import {
+  buildInitialPayload,
+  buildExecutePayload,
+  DynamicActionForm,
+} from "./DynamicActionForm";
 
 export function ChatPage() {
-  const [actionId, setActionId] = useState("");
-  const [schema, setSchema] = useState(null);
+  const [actions, setActions] = useState([]);
+  const [loadingList, setLoadingList] = useState(true);
+  const [selectedAction, setSelectedAction] = useState(null);
   const [payload, setPayload] = useState({});
   const [result, setResult] = useState(null);
-  const [loadingSchema, setLoadingSchema] = useState(false);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState(null);
   const { user, isAdmin, logout } = useAuth();
   const navigate = useNavigate();
 
-  const fields = useMemo(
-    () => chatFieldsFromInputSchemaJson(schema?.input_schema_json),
-    [schema],
-  );
-
-  async function loadSchema(event) {
-    event.preventDefault();
-    setLoadingSchema(true);
+  const loadActions = useCallback(async () => {
+    setLoadingList(true);
     setError(null);
-    setResult(null);
     try {
-      const list = await api.get("/actions");
-      const items = Array.isArray(list) ? list : [];
-      const found = items.find(
-        (a) => String(a?.id ?? "") === String(actionId).trim(),
-      );
-      if (!found) {
-        throw {
-          status: 404,
-          message: "Acción no encontrada en tus permisos o id incorrecto.",
-        };
-      }
-      setSchema(found);
-      const defaults = {};
-      for (const field of chatFieldsFromInputSchemaJson(
-        found?.input_schema_json,
-      )) {
-        defaults[field.name] = initialValueByType(field.type);
-      }
-      setPayload(defaults);
+      const data = await api.get("/actions");
+      setActions(Array.isArray(data) ? data : []);
     } catch (nextError) {
       setError(nextError);
-      setSchema(null);
+      setActions([]);
     } finally {
-      setLoadingSchema(false);
+      setLoadingList(false);
     }
+  }, []);
+
+  useEffect(() => {
+    loadActions();
+  }, [loadActions]);
+
+  function selectAction(action) {
+    setSelectedAction(action);
+    setResult(null);
+    setError(null);
+    const { defaults } = buildInitialPayload(action?.input_schema_json);
+    setPayload(defaults);
   }
 
-  async function executeAction(event) {
-    event.preventDefault();
+  async function executeAction() {
+    if (!selectedAction?.id) return;
     setSubmitting(true);
     setError(null);
     setResult(null);
     try {
-      const payloadObject = {};
-      for (const field of fields) {
-        payloadObject[field.name] = castValueByType(
-          field.type,
-          payload[field.name],
-        );
-      }
-      const execution = await api.post(`/actions/${actionId}/execute`, {
-        payload: payloadObject,
-      });
+      const payloadObject = buildExecutePayload(
+        selectedAction.input_schema_json,
+        payload,
+      );
+      const execution = await api.post(
+        `/actions/${selectedAction.id}/execute`,
+        { payload: payloadObject },
+      );
       setResult(execution);
     } catch (nextError) {
-      setError(nextError);
+      const st = nextError?.status;
+      if (st === 404 || st === 501) {
+        setError({
+          status: st,
+          message:
+            "La ejecución de acciones aún no está disponible. Disponible próximamente (task-08g-bis).",
+        });
+      } else {
+        setError(nextError);
+      }
     } finally {
       setSubmitting(false);
     }
@@ -174,18 +85,19 @@ export function ChatPage() {
       <section className="panel">
         <div className="page-header">
           <div>
-            <h1>Chat MVP</h1>
+            <h1>Asistente</h1>
             <small>
               Usuario: {user?.sub} ({user?.role})
             </small>
           </div>
           <div className="row">
             {isAdmin ? (
-              <button onClick={() => navigate("/admin/users")}>
+              <button type="button" onClick={() => navigate("/admin/users")}>
                 Ir a admin
               </button>
             ) : null}
             <button
+              type="button"
               onClick={async () => {
                 await logout();
                 navigate("/login");
@@ -196,56 +108,56 @@ export function ChatPage() {
           </div>
         </div>
         <ApiErrorBanner error={error} />
-        <form className="row" onSubmit={loadSchema}>
-          <label className="field">
-            action_id
-            <input
-              aria-label="action_id"
-              value={actionId}
-              onChange={(event) => setActionId(event.target.value)}
-              required
-            />
-          </label>
-          <button
-            className="primary"
-            type="submit"
-            disabled={loadingSchema || !actionId}
-          >
-            {loadingSchema ? "Cargando schema..." : "Cargar schema"}
-          </button>
-        </form>
+        <p className="text-sm muted" style={{ marginTop: 0 }}>
+          Elige una acción para rellenar el formulario y ejecutarla.
+        </p>
       </section>
 
-      {loadingSchema ? <LoadingBlock /> : null}
+      {loadingList ? <LoadingBlock label="Cargando acciones…" /> : null}
 
-      {schema ? (
-        <section className="panel">
-          <h2>Formulario dinámico ({schema.input_schema_version || "v1"})</h2>
-          <form className="stack" onSubmit={executeAction}>
-            {fields.map((field) => (
-              <label key={field.name} className="field">
-                {field.label || field.name}
-                <FieldRenderer
-                  field={field}
-                  value={payload[field.name] ?? ""}
-                  onChange={(next) =>
-                    setPayload((prev) => ({ ...prev, [field.name]: next }))
-                  }
-                />
-              </label>
-            ))}
-            <button className="primary" type="submit" disabled={submitting}>
-              {submitting ? "Ejecutando..." : "Ejecutar acción"}
-            </button>
-          </form>
-        </section>
+      {!loadingList && !error && actions.length === 0 ? (
+        <EmptyState
+          title="No hay acciones disponibles"
+          description="Cuando existan acciones en tu espacio, aparecerán aquí para ejecutarlas."
+        />
       ) : null}
 
-      {result ? (
-        <section className="panel">
-          <h2>Resultado</h2>
-          <pre>{JSON.stringify(result, null, 2)}</pre>
-        </section>
+      {!loadingList && !error && actions.length > 0 ? (
+        <div className="chat-workspace">
+          <section className="panel">
+            <h2 style={{ marginTop: 0, fontSize: "1.05rem" }}>Acciones</h2>
+            <AllowedActionsList
+              actions={actions}
+              selectedId={selectedAction?.id}
+              onSelect={selectAction}
+            />
+          </section>
+
+          <section className="panel">
+            {selectedAction ? (
+              <>
+                <h2 style={{ marginTop: 0, fontSize: "1.15rem" }}>
+                  {selectedAction.name?.trim() || "Acción sin nombre"}
+                </h2>
+                <DynamicActionForm
+                  schemaJson={selectedAction.input_schema_json}
+                  schemaVersion={selectedAction.input_schema_version}
+                  payload={payload}
+                  onPayloadChange={setPayload}
+                  onSubmit={executeAction}
+                  submitting={submitting}
+                  submitLabel="Ejecutar"
+                />
+                <ActionExecutionResult result={result} />
+              </>
+            ) : (
+              <EmptyState
+                title="Selecciona una acción"
+                description="Pulsa una acción de la lista para ver el formulario y ejecutarla."
+              />
+            )}
+          </section>
+        </div>
       ) : null}
 
       <PreferencesPanel />

--- a/apps/web/src/modules/chat/DynamicActionForm.jsx
+++ b/apps/web/src/modules/chat/DynamicActionForm.jsx
@@ -1,0 +1,165 @@
+import { useMemo } from "react";
+import {
+  castPayloadValue,
+  chatFieldsFromInputSchemaJson,
+  initialValueForField,
+} from "../admin/adminHelpers";
+
+function FieldControl({ field, value, onChange }) {
+  const options = field.options || [];
+  switch (field.type) {
+    case "textarea":
+      return (
+        <textarea
+          rows={4}
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+        />
+      );
+    case "number":
+      return (
+        <input
+          type="number"
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+        />
+      );
+    case "boolean":
+      return (
+        <input
+          type="checkbox"
+          checked={Boolean(value)}
+          onChange={(e) => onChange(e.target.checked)}
+        />
+      );
+    case "select":
+      return (
+        <select value={value} onChange={(e) => onChange(e.target.value)}>
+          <option value="">—</option>
+          {options.map((opt) => (
+            <option
+              key={String(opt.value ?? opt)}
+              value={String(opt.value ?? opt)}
+            >
+              {opt.label ?? opt.value ?? opt}
+            </option>
+          ))}
+        </select>
+      );
+    case "radio":
+      return (
+        <div className="row">
+          {options.map((opt) => {
+            const optionValue = String(opt.value ?? opt);
+            return (
+              <label key={optionValue}>
+                <input
+                  type="radio"
+                  name={field.name}
+                  checked={String(value) === optionValue}
+                  onChange={() => onChange(optionValue)}
+                />
+                {opt.label ?? opt.value ?? opt}
+              </label>
+            );
+          })}
+        </div>
+      );
+    case "date":
+      return (
+        <input
+          type="date"
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+        />
+      );
+    default:
+      return (
+        <input
+          type="text"
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+        />
+      );
+  }
+}
+
+export function buildInitialPayload(schemaJson) {
+  const fields = chatFieldsFromInputSchemaJson(schemaJson);
+  const defaults = {};
+  for (const field of fields) {
+    defaults[field.name] = initialValueForField(field);
+  }
+  return { fields, defaults };
+}
+
+export function buildExecutePayload(schemaJson, payload) {
+  const fields = chatFieldsFromInputSchemaJson(schemaJson);
+  const payloadObject = {};
+  for (const field of fields) {
+    payloadObject[field.name] = castPayloadValue(field, payload[field.name]);
+  }
+  return payloadObject;
+}
+
+export function DynamicActionForm({
+  schemaJson,
+  schemaVersion,
+  payload,
+  onPayloadChange,
+  onSubmit,
+  submitting,
+  submitLabel = "Ejecutar",
+}) {
+  const fields = useMemo(
+    () => chatFieldsFromInputSchemaJson(schemaJson),
+    [schemaJson],
+  );
+
+  return (
+    <form
+      className="stack"
+      onSubmit={(e) => {
+        e.preventDefault();
+        onSubmit();
+      }}
+    >
+      {schemaVersion ? (
+        <p className="text-sm muted">Esquema v{schemaVersion}</p>
+      ) : null}
+      {fields.length === 0 ? (
+        <p className="text-sm muted">
+          Esta acción no define parámetros de entrada.
+        </p>
+      ) : null}
+      {fields.map((field) => (
+        <label key={field.name} className="field">
+          <span>
+            {field.label || field.name}
+            {field.required ? (
+              <span className="muted" aria-hidden>
+                {" "}
+                *
+              </span>
+            ) : null}
+          </span>
+          {field.description ? (
+            <span className="text-sm muted">{field.description}</span>
+          ) : null}
+          <FieldControl
+            field={field}
+            value={payload[field.name] ?? ""}
+            onChange={(next) =>
+              onPayloadChange((prev) => ({ ...prev, [field.name]: next }))
+            }
+          />
+        </label>
+      ))}
+      <div>
+        <button className="primary" type="submit" disabled={submitting}>
+          {submitting ? "Ejecutando…" : submitLabel}
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -400,6 +400,18 @@ button.danger {
   grid-template-columns: minmax(220px, 280px) 1fr;
 }
 
+.chat-workspace {
+  display: grid;
+  gap: 16px;
+  grid-template-columns: minmax(220px, 280px) 1fr;
+}
+
+@media (max-width: 768px) {
+  .chat-workspace {
+    grid-template-columns: 1fr;
+  }
+}
+
 .connector-list {
   display: grid;
   gap: 8px;

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -430,6 +430,15 @@ button.danger {
   background: #eef2ff;
 }
 
+.allowed-action-meta {
+  font-family:
+    ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono",
+    monospace;
+  font-size: 0.75rem;
+  color: #64748b;
+  line-height: 1.35;
+}
+
 .panel.subtle {
   background: #fbfcff;
 }

--- a/apps/web/src/test/smoke.test.jsx
+++ b/apps/web/src/test/smoke.test.jsx
@@ -96,17 +96,41 @@ describe("smoke routes", () => {
         user: { sub: "user@test", tenant_id: "t1", role: "user" },
       }),
     );
-    fetch.mockImplementation(() =>
-      mockJsonResponse(200, { theme: "system", metadata: {} }),
-    );
+    fetch.mockImplementation((url, options = {}) => {
+      const path = String(url).replace("http://localhost:8000", "");
+      const method = String(options.method || "GET").toUpperCase();
+      if (method === "GET" && path === "/me/preferences") {
+        return mockJsonResponse(200, { theme: "system", metadata: {} });
+      }
+      if (method === "GET" && path === "/actions") {
+        return mockJsonResponse(200, [
+          {
+            id: "a1",
+            name: "Demo",
+            method: "GET",
+            path: "/v1/demo",
+            connector_id: "c1",
+            input_schema_json: { type: "object", properties: {} },
+            input_schema_version: 1,
+            tag_ids: [],
+          },
+        ]);
+      }
+      return mockJsonResponse(500, {
+        detail: `Mock no definido: ${method} ${path}`,
+      });
+    });
 
     renderWithRoute("/chat");
     expect(
-      await screen.findByRole("heading", { name: "Chat MVP" }),
+      await screen.findByRole("heading", { name: "Asistente" }),
     ).toBeInTheDocument();
     expect(
       screen.getByRole("heading", { name: "Preferencias" }),
     ).toBeInTheDocument();
+    expect(screen.queryByLabelText("action_id")).not.toBeInTheDocument();
+    expect(screen.queryByText(/Cargar schema/i)).not.toBeInTheDocument();
+    expect(await screen.findByText("Demo")).toBeInTheDocument();
   });
 
   it("renderiza workspace de conectores sin pedir connector_id manual", async () => {


### PR DESCRIPTION
## Enlaces
- Jira: [CRYPT-10](https://cryptarch.atlassian.net/browse/CRYPT-10)
- Engram: tasks/CRYPT-10

## Summary
Rewrites `ChatPage` as a real assistant workspace. Users pick an allowed action from a list and fill a dynamic form generated from `input_schema_json`. Removes manual schema loading and technical IDs.

## Changes
- `apps/web/src/modules/chat/ChatPage.jsx` rewritten; uses `GET /actions` (the new end-user endpoint) instead of `/admin/actions`.
- New: `AllowedActionsList.jsx` (now shows `method` + `path`), `DynamicActionForm.jsx`, `ActionExecutionResult.jsx`, `schemaFields.js`.
- `apps/web/src/styles.css` adds `.chat-workspace`, mobile breakpoint and `.allowed-action-meta`.
- Smoke test updated to the new "Asistente" UI with mocked `GET /actions`.
- Defensive UX on execute: while task-08g-bis (#19) is not deployed, `POST /actions/:id/execute` returns 404; the UI catches this and shows a clear "execution not available yet" message.
- `PreferencesPanel` left untouched (belongs to task-13h1).

## Dependencies
- ✅ #18 `GET /actions` (allowed for end user) — merged in develop via PR #22.
- ⏳ #19 `POST /actions/:id/execute` — pending; UI handles its absence gracefully.

## Acceptance criteria
- [x] No `action_id` input visible
- [x] No "Load schema" button
- [x] Allowed actions list + dynamic form + legible result
- [x] Method/path visible per action
- [x] Graceful UX when execute endpoint is missing
- [ ] E2E tested (task-13h2, later)

## Tests
- Frontend: `npm run test` — 16/16 passed (vitest).
- Backend untouched.

Closes #15
