### PR TITLE
feat(api,web): CRYPT-55 unify input_schema_json contract

### DIFF
--- a/apps/api/adapters/driving/http/admin/routes_actions.py
+++ b/apps/api/adapters/driving/http/admin/routes_actions.py
@@ -10,6 +10,7 @@ from core.application.action import (
     TagNotFoundError,
 )
 from core.domain.action_request_config import RequestConfigValidationError
+from core.domain.input_schema_contract import InputSchemaValidationError
 from dependencies import CurrentUser, get_db, require_admin
 from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.orm import Session
@@ -109,6 +110,12 @@ def create_action(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
             detail=str(exc),
         ) from exc
+    except InputSchemaValidationError as exc:
+        db.rollback()
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=str(exc),
+        ) from exc
     except ConnectorNotFoundError:
         db.rollback()
         raise HTTPException(
@@ -151,6 +158,12 @@ def update_action(
         )
         db.commit()
     except RequestConfigValidationError as exc:
+        db.rollback()
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=str(exc),
+        ) from exc
+    except InputSchemaValidationError as exc:
         db.rollback()
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,

--- a/apps/api/core/application/action.py
+++ b/apps/api/core/application/action.py
@@ -6,6 +6,10 @@ Validate connector_id and tag_ids in tenant. No Session or DB in this module; po
 from typing import Any
 
 from core.domain.action_request_config import validate_and_normalize_request_config
+from core.domain.input_schema_contract import (
+    InputSchemaValidationError,
+    validate_and_normalize_input_schema_json,
+)
 from core.domain.models import Action
 from core.ports.action_repository import ActionRepository
 from core.ports.connector_repository import ConnectorRepository
@@ -79,6 +83,7 @@ def create_action(
     _validate_tag_ids_in_tenant(tag_ids, tenant_id, tag_repo)
     method_norm = _normalize_method(method)
     rc_norm = validate_and_normalize_request_config(method_norm, request_config)
+    schema_norm = validate_and_normalize_input_schema_json(input_schema_json)
     action = Action(
         tenant_id=tenant_id,
         connector_id=connector.id,
@@ -86,7 +91,7 @@ def create_action(
         path=path,
         name=name,
         request_config=rc_norm,
-        input_schema_json=input_schema_json,
+        input_schema_json=schema_norm,
         input_schema_version=input_schema_version,
     )
     return repo.add(action, tag_ids)
@@ -128,7 +133,9 @@ def update_action(
             action.request_config,
         )
     if input_schema_json is not None:
-        action.input_schema_json = input_schema_json
+        action.input_schema_json = validate_and_normalize_input_schema_json(
+            input_schema_json,
+        )
     if input_schema_version is not None:
         action.input_schema_version = input_schema_version
     return repo.save(action, tag_ids)

--- a/apps/api/core/application/action.py
+++ b/apps/api/core/application/action.py
@@ -6,10 +6,7 @@ Validate connector_id and tag_ids in tenant. No Session or DB in this module; po
 from typing import Any
 
 from core.domain.action_request_config import validate_and_normalize_request_config
-from core.domain.input_schema_contract import (
-    InputSchemaValidationError,
-    validate_and_normalize_input_schema_json,
-)
+from core.domain.input_schema_contract import validate_and_normalize_input_schema_json
 from core.domain.models import Action
 from core.ports.action_repository import ActionRepository
 from core.ports.connector_repository import ConnectorRepository

--- a/apps/api/core/domain/input_schema_contract.py
+++ b/apps/api/core/domain/input_schema_contract.py
@@ -45,11 +45,15 @@ def validate_and_normalize_input_schema_json(raw: Any) -> dict[str, Any] | None:
         )
     schema_type = raw.get("type")
     if schema_type is not None and schema_type != "object":
-        raise InputSchemaValidationError("input_schema_json.type must be 'object' when set")
+        raise InputSchemaValidationError(
+            "input_schema_json.type must be 'object' when set"
+        )
     properties = raw.get("properties")
     if properties is not None:
         if not isinstance(properties, dict):
-            raise InputSchemaValidationError("input_schema_json.properties must be an object")
+            raise InputSchemaValidationError(
+                "input_schema_json.properties must be an object"
+            )
         for key, definition in properties.items():
             if not isinstance(definition, dict):
                 raise InputSchemaValidationError(
@@ -63,7 +67,9 @@ def validate_and_normalize_input_schema_json(raw: Any) -> dict[str, Any] | None:
                 )
     required = raw.get("required")
     if required is not None:
-        if not isinstance(required, list) or not all(isinstance(x, str) for x in required):
+        if not isinstance(required, list) or not all(
+            isinstance(x, str) for x in required
+        ):
             raise InputSchemaValidationError(
                 "input_schema_json.required must be an array of strings",
             )

--- a/apps/api/core/domain/input_schema_contract.py
+++ b/apps/api/core/domain/input_schema_contract.py
@@ -1,0 +1,70 @@
+"""Canonical contract for Action.input_schema_json (JSON Schema subset).
+
+Storage and API surface use a JSON Schema object: ``type: object`` with optional
+``properties`` and ``required``. Admin builds this shape via ``buildSchemaFromFields``;
+chat maps it to renderable fields at the UI boundary (see web ``chatFieldsFromInputSchemaJson``).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+ALLOWED_PROPERTY_TYPES = frozenset({"string", "number", "integer", "boolean"})
+
+
+class InputSchemaValidationError(ValueError):
+    """input_schema_json is not a valid Cryptarch action input schema document."""
+
+
+def _property_type_ok(raw: Any) -> bool:
+    if raw is None:
+        return True
+    if isinstance(raw, str):
+        return raw in ALLOWED_PROPERTY_TYPES or raw == "null"
+    if isinstance(raw, list):
+        return all(
+            isinstance(x, str) and (x in ALLOWED_PROPERTY_TYPES or x == "null")
+            for x in raw
+        )
+    return False
+
+
+def validate_and_normalize_input_schema_json(raw: Any) -> dict[str, Any] | None:
+    """Validate ``input_schema_json`` for create/update. Returns the same dict or None.
+
+    Rejects legacy chat-only shapes such as ``{"fields": [...]}`` without JSON Schema properties.
+    """
+    if raw is None:
+        return None
+    if not isinstance(raw, dict):
+        raise InputSchemaValidationError("input_schema_json must be a JSON object")
+    if "fields" in raw and "properties" not in raw:
+        raise InputSchemaValidationError(
+            "input_schema_json must follow JSON Schema (object with properties); "
+            "legacy {fields: [...]} is not accepted on the API"
+        )
+    schema_type = raw.get("type")
+    if schema_type is not None and schema_type != "object":
+        raise InputSchemaValidationError("input_schema_json.type must be 'object' when set")
+    properties = raw.get("properties")
+    if properties is not None:
+        if not isinstance(properties, dict):
+            raise InputSchemaValidationError("input_schema_json.properties must be an object")
+        for key, definition in properties.items():
+            if not isinstance(definition, dict):
+                raise InputSchemaValidationError(
+                    f"input_schema_json.properties[{key!r}] must be an object",
+                )
+            if not _property_type_ok(definition.get("type")):
+                raise InputSchemaValidationError(
+                    f"input_schema_json.properties[{key!r}].type must be a string, "
+                    f"array of strings, or omitted (allowed: "
+                    f"{', '.join(sorted(ALLOWED_PROPERTY_TYPES))}, null)",
+                )
+    required = raw.get("required")
+    if required is not None:
+        if not isinstance(required, list) or not all(isinstance(x, str) for x in required):
+            raise InputSchemaValidationError(
+                "input_schema_json.required must be an array of strings",
+            )
+    return raw

--- a/apps/api/tests/test_admin_actions_crud.py
+++ b/apps/api/tests/test_admin_actions_crud.py
@@ -493,6 +493,38 @@ def test_create_action_post_with_body_in_config_201(
     assert data["request_config"]["headers"]["Content-Type"] == "application/json"
 
 
+def test_create_action_invalid_input_schema_422(
+    client: TestClient, tenant, admin_user, connector
+):
+    r = client.post(
+        "/admin/actions",
+        headers=_auth_headers(tenant.id, admin_user.id),
+        json={
+            "connector_id": str(uuid.UUID(connector.id)),
+            "method": "GET",
+            "path": "/items",
+            "input_schema_json": {"type": "string"},
+        },
+    )
+    assert r.status_code == 422
+
+
+def test_create_action_rejects_legacy_fields_wrapper_422(
+    client: TestClient, tenant, admin_user, connector
+):
+    r = client.post(
+        "/admin/actions",
+        headers=_auth_headers(tenant.id, admin_user.id),
+        json={
+            "connector_id": str(uuid.UUID(connector.id)),
+            "method": "GET",
+            "path": "/items",
+            "input_schema_json": {"fields": [{"name": "x", "type": "text"}]},
+        },
+    )
+    assert r.status_code == 422
+
+
 def test_create_action_persists_input_schema_roundtrip(
     client: TestClient, tenant, admin_user, connector
 ):

--- a/apps/api/tests/test_input_schema_contract.py
+++ b/apps/api/tests/test_input_schema_contract.py
@@ -1,7 +1,6 @@
 """Unit tests for action input_schema JSON Schema subset (no DB)."""
 
 import pytest
-
 from core.domain.input_schema_contract import (
     InputSchemaValidationError,
     validate_and_normalize_input_schema_json,

--- a/apps/api/tests/test_input_schema_contract.py
+++ b/apps/api/tests/test_input_schema_contract.py
@@ -1,0 +1,49 @@
+"""Unit tests for action input_schema JSON Schema subset (no DB)."""
+
+import pytest
+
+from core.domain.input_schema_contract import (
+    InputSchemaValidationError,
+    validate_and_normalize_input_schema_json,
+)
+
+
+def test_none_is_valid():
+    assert validate_and_normalize_input_schema_json(None) is None
+
+
+def test_minimal_object_schema():
+    raw = {"type": "object", "properties": {}}
+    assert validate_and_normalize_input_schema_json(raw) == raw
+
+
+def test_rejects_non_object_root():
+    with pytest.raises(InputSchemaValidationError, match="JSON object"):
+        validate_and_normalize_input_schema_json("x")
+
+
+def test_rejects_wrong_top_level_type():
+    with pytest.raises(InputSchemaValidationError, match="'object'"):
+        validate_and_normalize_input_schema_json({"type": "string"})
+
+
+def test_rejects_legacy_fields_only_wrapper():
+    with pytest.raises(InputSchemaValidationError, match="legacy"):
+        validate_and_normalize_input_schema_json({"fields": [{"name": "a"}]})
+
+
+def test_property_type_must_be_allowed():
+    with pytest.raises(InputSchemaValidationError, match="properties\\['x'\\].type"):
+        validate_and_normalize_input_schema_json(
+            {
+                "type": "object",
+                "properties": {"x": {"type": "object"}},
+            },
+        )
+
+
+def test_required_must_be_string_list():
+    with pytest.raises(InputSchemaValidationError, match="required"):
+        validate_and_normalize_input_schema_json(
+            {"type": "object", "properties": {}, "required": [1]},
+        )

--- a/apps/api/tests/test_user_actions_list.py
+++ b/apps/api/tests/test_user_actions_list.py
@@ -384,6 +384,8 @@ def test_response_does_not_expose_request_config_or_credentials(
     body = payload[0]
     assert body["method"] == "POST"
     assert body["path"] == "/exec"
+    assert body["input_schema_json"] == {"type": "object"}
+    assert body["input_schema_version"] == "1"
     assert "request_config" not in body
     assert "auth_config" not in body
     assert "base_url" not in body

--- a/apps/web/src/modules/admin/adminHelpers.js
+++ b/apps/web/src/modules/admin/adminHelpers.js
@@ -97,12 +97,14 @@ export function chatFieldsFromInputSchemaJson(raw) {
   }
 
   const properties = raw.properties;
-  if (!properties || typeof properties !== "object" || Array.isArray(properties))
+  if (
+    !properties ||
+    typeof properties !== "object" ||
+    Array.isArray(properties)
+  )
     return [];
 
-  const requiredSet = new Set(
-    Array.isArray(raw.required) ? raw.required : [],
-  );
+  const requiredSet = new Set(Array.isArray(raw.required) ? raw.required : []);
   return Object.entries(properties).map(([name, definition]) => {
     const d =
       definition && typeof definition === "object" && !Array.isArray(definition)
@@ -116,7 +118,9 @@ export function chatFieldsFromInputSchemaJson(raw) {
     let widgetType = "text";
     let options;
     const title =
-      typeof d.title === "string" && d.title.trim() !== "" ? d.title.trim() : name;
+      typeof d.title === "string" && d.title.trim() !== ""
+        ? d.title.trim()
+        : name;
 
     if (jsType === "boolean") {
       widgetType = "boolean";
@@ -129,10 +133,7 @@ export function chatFieldsFromInputSchemaJson(raw) {
           value: v,
           label: String(v),
         }));
-      } else if (
-        d.format === "textarea" ||
-        d["x-ui-widget"] === "textarea"
-      ) {
+      } else if (d.format === "textarea" || d["x-ui-widget"] === "textarea") {
         widgetType = "textarea";
       } else {
         widgetType = "text";

--- a/apps/web/src/modules/admin/adminHelpers.js
+++ b/apps/web/src/modules/admin/adminHelpers.js
@@ -71,6 +71,85 @@ export function extractSchemaFields(schema) {
   }));
 }
 
+/**
+ * Canonical API/admin storage: JSON Schema object (`type`, `properties`, `required`).
+ * Chat dynamic UI fields: `{ name, type, label, description?, options?, required? }`.
+ * Also accepts legacy `{ fields: [...] }` from older clients when reading only.
+ */
+export function chatFieldsFromInputSchemaJson(raw) {
+  if (raw == null || typeof raw !== "object") return [];
+  if (Array.isArray(raw.fields)) {
+    return raw.fields
+      .filter((f) => f && String(f.name || "").trim())
+      .map((f) => ({
+        name: String(f.name).trim(),
+        type: f.type || "text",
+        label:
+          f.label != null && String(f.label).trim() !== ""
+            ? String(f.label).trim()
+            : String(f.name).trim(),
+        description: f.description || "",
+        required: Boolean(f.required),
+        ...(Array.isArray(f.options) && f.options.length > 0
+          ? { options: f.options }
+          : {}),
+      }));
+  }
+
+  const properties = raw.properties;
+  if (!properties || typeof properties !== "object" || Array.isArray(properties))
+    return [];
+
+  const requiredSet = new Set(
+    Array.isArray(raw.required) ? raw.required : [],
+  );
+  return Object.entries(properties).map(([name, definition]) => {
+    const d =
+      definition && typeof definition === "object" && !Array.isArray(definition)
+        ? definition
+        : {};
+    const rawType = d.type;
+    const jsType = Array.isArray(rawType)
+      ? rawType.find((t) => t && t !== "null")
+      : rawType;
+
+    let widgetType = "text";
+    let options;
+    const title =
+      typeof d.title === "string" && d.title.trim() !== "" ? d.title.trim() : name;
+
+    if (jsType === "boolean") {
+      widgetType = "boolean";
+    } else if (jsType === "number" || jsType === "integer") {
+      widgetType = "number";
+    } else if (jsType === "string" || jsType === undefined || jsType === null) {
+      if (Array.isArray(d.enum) && d.enum.length > 0) {
+        widgetType = "select";
+        options = d.enum.map((v) => ({
+          value: v,
+          label: String(v),
+        }));
+      } else if (
+        d.format === "textarea" ||
+        d["x-ui-widget"] === "textarea"
+      ) {
+        widgetType = "textarea";
+      } else {
+        widgetType = "text";
+      }
+    }
+
+    return {
+      name,
+      type: widgetType,
+      label: title,
+      description: typeof d.description === "string" ? d.description : "",
+      required: requiredSet.has(name),
+      ...(options ? { options } : {}),
+    };
+  });
+}
+
 export function extractFileName(path) {
   if (!path) return "Documento";
   const normalized = String(path).replaceAll("\\", "/");

--- a/apps/web/src/modules/admin/adminHelpers.test.js
+++ b/apps/web/src/modules/admin/adminHelpers.test.js
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   buildAuthConfigFromConnectorForm,
+  chatFieldsFromInputSchemaJson,
   emptyConnectorAuthFormFields,
   joinBaseUrlAndPath,
   parseConnectorAuthForForm,
@@ -23,6 +24,88 @@ describe("joinBaseUrlAndPath", () => {
     expect(joinBaseUrlAndPath("https://a.com", "https://other/full")).toBe(
       "https://other/full",
     );
+  });
+});
+
+describe("chatFieldsFromInputSchemaJson", () => {
+  it("convierte JSON Schema del admin a campos de UI", () => {
+    const schema = {
+      type: "object",
+      required: ["title"],
+      properties: {
+        title: { type: "string", description: "Título" },
+        count: { type: "integer" },
+        done: { type: "boolean" },
+      },
+    };
+    const fields = chatFieldsFromInputSchemaJson(schema);
+    expect(fields).toHaveLength(3);
+    expect(fields[0]).toMatchObject({
+      name: "title",
+      type: "text",
+      label: "title",
+      description: "Título",
+      required: true,
+    });
+    expect(fields[1]).toMatchObject({
+      name: "count",
+      type: "number",
+      required: false,
+    });
+    expect(fields[2]).toMatchObject({
+      name: "done",
+      type: "boolean",
+      required: false,
+    });
+  });
+
+  it("usa enum como select y title como label", () => {
+    const schema = {
+      type: "object",
+      properties: {
+        size: {
+          type: "string",
+          title: "Tamaño",
+          enum: ["S", "M"],
+        },
+      },
+    };
+    const [field] = chatFieldsFromInputSchemaJson(schema);
+    expect(field.type).toBe("select");
+    expect(field.label).toBe("Tamaño");
+    expect(field.options).toEqual([
+      { value: "S", label: "S" },
+      { value: "M", label: "M" },
+    ]);
+  });
+
+  it("acepta formato textarea vía format o x-ui-widget", () => {
+    expect(
+      chatFieldsFromInputSchemaJson({
+        type: "object",
+        properties: { notes: { type: "string", format: "textarea" } },
+      })[0].type,
+    ).toBe("textarea");
+    expect(
+      chatFieldsFromInputSchemaJson({
+        type: "object",
+        properties: { notes: { type: "string", "x-ui-widget": "textarea" } },
+      })[0].type,
+    ).toBe("textarea");
+  });
+
+  it("retrocompatibilidad: wrapper legacy fields[]", () => {
+    const fields = chatFieldsFromInputSchemaJson({
+      fields: [
+        {
+          name: "a",
+          type: "number",
+          label: "A",
+          required: true,
+        },
+      ],
+    });
+    expect(fields[0]).toMatchObject({ name: "a", type: "number", label: "A" });
   });
 });
 

--- a/apps/web/src/modules/chat/ChatPage.jsx
+++ b/apps/web/src/modules/chat/ChatPage.jsx
@@ -131,7 +131,9 @@ export function ChatPage() {
       }
       setSchema(found);
       const defaults = {};
-      for (const field of chatFieldsFromInputSchemaJson(found?.input_schema_json)) {
+      for (const field of chatFieldsFromInputSchemaJson(
+        found?.input_schema_json,
+      )) {
         defaults[field.name] = initialValueByType(field.type);
       }
       setPayload(defaults);

--- a/apps/web/src/modules/chat/ChatPage.jsx
+++ b/apps/web/src/modules/chat/ChatPage.jsx
@@ -4,14 +4,11 @@ import { useAuth } from "../../app/AuthProvider";
 import { api } from "../../shared/apiClient";
 import { ApiErrorBanner, LoadingBlock } from "../../shared/ui";
 import { PreferencesPanel } from "../preferences/PreferencesPanel";
+import { chatFieldsFromInputSchemaJson } from "../admin/adminHelpers";
 
 function initialValueByType(type) {
   if (type === "boolean") return false;
   return "";
-}
-
-function normalizeFields(schema) {
-  return Array.isArray(schema?.fields) ? schema.fields : [];
 }
 
 function castValueByType(type, value) {
@@ -111,7 +108,7 @@ export function ChatPage() {
   const navigate = useNavigate();
 
   const fields = useMemo(
-    () => normalizeFields(schema?.input_schema_json),
+    () => chatFieldsFromInputSchemaJson(schema?.input_schema_json),
     [schema],
   );
 
@@ -121,10 +118,20 @@ export function ChatPage() {
     setError(null);
     setResult(null);
     try {
-      const data = await api.get(`/actions/${actionId}/input-schema`);
-      setSchema(data);
+      const list = await api.get("/actions");
+      const items = Array.isArray(list) ? list : [];
+      const found = items.find(
+        (a) => String(a?.id ?? "") === String(actionId).trim(),
+      );
+      if (!found) {
+        throw {
+          status: 404,
+          message: "Acción no encontrada en tus permisos o id incorrecto.",
+        };
+      }
+      setSchema(found);
       const defaults = {};
-      for (const field of normalizeFields(data?.input_schema_json)) {
+      for (const field of chatFieldsFromInputSchemaJson(found?.input_schema_json)) {
         defaults[field.name] = initialValueByType(field.type);
       }
       setPayload(defaults);


### PR DESCRIPTION
## Enlaces
- Jira: CRYPT-55 — Unificar contrato input_schema_json entre admin, API y chat
- Engram: tasks/CRYPT-55

## Summary
- Contrato compartido `input_schema_json` en dominio API (`input_schema_contract`) y uso en capa application y rutas admin.
- Tests API nuevos/ajustados para el contrato y CRUD/listados de acciones.
- Admin web y chat alineados con la misma semántica de esquema (helpers + `ChatPage`).

## Test plan
- [ ] `pytest apps/api/tests/test_input_schema_contract.py apps/api/tests/test_admin_actions_crud.py apps/api/tests/test_user_actions_list.py`
- [ ] Tests front: `npm test` o el runner del paquete web para `adminHelpers.test.js`
- [ ] Smoke manual: crear/editar acción en admin con `input_schema_json`; comprobar formulario en chat si aplica
