### PR TITLE
feat(api): CRYPT-9 POST /actions/{id}/execute

### DIFF
--- a/apps/api/adapters/driving/http/actions/routes.py
+++ b/apps/api/adapters/driving/http/actions/routes.py
@@ -2,14 +2,23 @@
 
 from typing import Annotated
 
-from core.application import user_action_list
+from core.application import user_action_execute, user_action_list
+from core.application.user_action_execute import (
+    ActionNotFoundError,
+    ActionNotPermittedError,
+)
+from core.domain.input_schema_contract import ActionPayloadValidationError
 from dependencies import CurrentUser, get_current_user, get_db
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.orm import Session
 
 from adapters.driven.persistence.action_repository import ActionRepositoryImpl
 from adapters.driven.persistence.permission_query import PermissionQueryImpl
 from adapters.driving.schemas.user_action import permitted_action_summary_to_response
+from adapters.driving.schemas.user_action_execute import (
+    ExecuteActionBody,
+    execute_action_result_to_response,
+)
 
 router = APIRouter(tags=["actions"])
 
@@ -29,3 +38,40 @@ def list_permitted_actions(
         action_repo,
     )
     return [permitted_action_summary_to_response(r) for r in rows]
+
+
+@router.post("/actions/{action_id}/execute")
+def execute_action(
+    action_id: str,
+    body: ExecuteActionBody,
+    current_user: Annotated[CurrentUser, Depends(get_current_user)],
+    db: Annotated[Session, Depends(get_db)],
+):
+    """Execute an allowed action (stub). Validates payload against input_schema_json."""
+    permission_port = PermissionQueryImpl(db)
+    action_repo = ActionRepositoryImpl(db)
+    try:
+        result = user_action_execute.execute_action_for_user(
+            current_user.tenant_id,
+            current_user.sub,
+            action_id,
+            body.payload,
+            permission_port,
+            action_repo,
+        )
+    except ActionNotFoundError:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Action not found",
+        )
+    except ActionNotPermittedError:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Action not permitted",
+        )
+    except ActionPayloadValidationError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=str(exc),
+        )
+    return execute_action_result_to_response(result)

--- a/apps/api/adapters/driving/schemas/user_action_execute.py
+++ b/apps/api/adapters/driving/schemas/user_action_execute.py
@@ -2,10 +2,10 @@
 
 from typing import Any
 
+from core.application.user_action_execute import ExecuteActionResult
 from pydantic import BaseModel
 
 from adapters.driving.schemas.action import _canonical_str
-from core.application.user_action_execute import ExecuteActionResult
 
 
 class ExecuteActionBody(BaseModel):

--- a/apps/api/adapters/driving/schemas/user_action_execute.py
+++ b/apps/api/adapters/driving/schemas/user_action_execute.py
@@ -1,0 +1,21 @@
+"""Request/response schemas for POST /actions/{action_id}/execute."""
+
+from typing import Any
+
+from pydantic import BaseModel
+
+from adapters.driving.schemas.action import _canonical_str
+from core.application.user_action_execute import ExecuteActionResult
+
+
+class ExecuteActionBody(BaseModel):
+    payload: dict[str, Any] = {}
+
+
+def execute_action_result_to_response(result: ExecuteActionResult) -> dict[str, Any]:
+    return {
+        "status": result.status,
+        "message": result.message,
+        "action_id": _canonical_str(result.action_id),
+        "received_payload": result.received_payload,
+    }

--- a/apps/api/core/application/user_action_execute.py
+++ b/apps/api/core/application/user_action_execute.py
@@ -57,9 +57,7 @@ def execute_action_for_user(
     allowed_ids = permission_service.resolve_effective_action_ids(
         permission_port, tenant_id, user_id
     )
-    allowed_keys = {
-        k for aid in allowed_ids if (k := _canonical_key(aid)) is not None
-    }
+    allowed_keys = {k for aid in allowed_ids if (k := _canonical_key(aid)) is not None}
     resolved_key = _canonical_key(action.id)
     if resolved_key is None or resolved_key not in allowed_keys:
         raise ActionNotPermittedError(action_id)

--- a/apps/api/core/application/user_action_execute.py
+++ b/apps/api/core/application/user_action_execute.py
@@ -1,0 +1,74 @@
+"""
+Execute an action on behalf of an end user (stub): permissions, tenant scope, payload validation.
+"""
+
+import uuid
+from dataclasses import dataclass
+from typing import Any
+
+from core.domain import permission_service
+from core.domain.input_schema_contract import validate_action_payload
+from core.ports.action_repository import ActionRepository
+from core.ports.permission_query import PermissionQueryPort
+
+
+class ActionNotFoundError(Exception):
+    """Action does not exist or is outside the tenant."""
+
+
+class ActionNotPermittedError(Exception):
+    """User lacks effective permission to execute this action."""
+
+
+def _canonical_key(value: str) -> str | None:
+    v = value.strip()
+    try:
+        if len(v) == 32 and "-" not in v:
+            return str(uuid.UUID(hex=v))
+        return str(uuid.UUID(v))
+    except (ValueError, TypeError):
+        return None
+
+
+@dataclass(frozen=True)
+class ExecuteActionResult:
+    status: str
+    message: str
+    action_id: str
+    received_payload: dict[str, Any]
+
+
+def execute_action_for_user(
+    tenant_id: str,
+    user_id: str,
+    action_id: str,
+    payload: dict[str, Any],
+    permission_port: PermissionQueryPort,
+    action_repo: ActionRepository,
+) -> ExecuteActionResult:
+    action_key = _canonical_key(action_id)
+    if not action_key:
+        raise ActionNotFoundError(action_id)
+
+    action = action_repo.get_by_id(action_id, tenant_id)
+    if action is None or not action.id:
+        raise ActionNotFoundError(action_id)
+
+    allowed_ids = permission_service.resolve_effective_action_ids(
+        permission_port, tenant_id, user_id
+    )
+    allowed_keys = {
+        k for aid in allowed_ids if (k := _canonical_key(aid)) is not None
+    }
+    resolved_key = _canonical_key(action.id)
+    if resolved_key is None or resolved_key not in allowed_keys:
+        raise ActionNotPermittedError(action_id)
+
+    validated = validate_action_payload(payload, action.input_schema_json)
+
+    return ExecuteActionResult(
+        status="ok",
+        message="Action execution accepted (stub; connector call not implemented)",
+        action_id=action.id,
+        received_payload=validated,
+    )

--- a/apps/api/core/domain/input_schema_contract.py
+++ b/apps/api/core/domain/input_schema_contract.py
@@ -16,6 +16,10 @@ class InputSchemaValidationError(ValueError):
     """input_schema_json is not a valid Cryptarch action input schema document."""
 
 
+class ActionPayloadValidationError(ValueError):
+    """User payload does not satisfy the action input_schema_json contract."""
+
+
 def _property_type_ok(raw: Any) -> bool:
     if raw is None:
         return True
@@ -74,3 +78,67 @@ def validate_and_normalize_input_schema_json(raw: Any) -> dict[str, Any] | None:
                 "input_schema_json.required must be an array of strings",
             )
     return raw
+
+
+def _value_matches_property_type(value: Any, expected_type: Any) -> bool:
+    if expected_type is None:
+        return True
+    types: list[str]
+    if isinstance(expected_type, str):
+        types = [expected_type]
+    elif isinstance(expected_type, list):
+        types = [x for x in expected_type if isinstance(x, str)]
+    else:
+        return False
+    for t in types:
+        if t == "string" and isinstance(value, str):
+            return True
+        if t == "boolean" and isinstance(value, bool):
+            return True
+        if t == "integer" and type(value) is int and not isinstance(value, bool):
+            return True
+        if t == "number" and type(value) in (int, float) and not isinstance(value, bool):
+            return True
+        if t == "null" and value is None:
+            return True
+    return False
+
+
+def validate_action_payload(
+    payload: Any, input_schema_json: dict[str, Any] | None
+) -> dict[str, Any]:
+    """Validate execute payload against action input_schema_json. Returns payload dict."""
+    if not isinstance(payload, dict):
+        raise ActionPayloadValidationError("payload must be a JSON object")
+    if input_schema_json is None:
+        return payload
+    if not isinstance(input_schema_json, dict):
+        return payload
+    properties = input_schema_json.get("properties")
+    if properties is not None and not isinstance(properties, dict):
+        properties = {}
+    elif properties is None:
+        properties = {}
+    required = input_schema_json.get("required")
+    if required is not None:
+        if not isinstance(required, list):
+            required = []
+        for key in required:
+            if not isinstance(key, str):
+                continue
+            if key not in payload:
+                raise ActionPayloadValidationError(
+                    f"payload missing required property {key!r}"
+                )
+    for key, value in payload.items():
+        definition = properties.get(key)
+        if not isinstance(definition, dict):
+            continue
+        expected_type = definition.get("type")
+        if expected_type is not None and not _value_matches_property_type(
+            value, expected_type
+        ):
+            raise ActionPayloadValidationError(
+                f"payload property {key!r} has invalid type for schema",
+            )
+    return payload

--- a/apps/api/core/domain/input_schema_contract.py
+++ b/apps/api/core/domain/input_schema_contract.py
@@ -97,7 +97,11 @@ def _value_matches_property_type(value: Any, expected_type: Any) -> bool:
             return True
         if t == "integer" and type(value) is int and not isinstance(value, bool):
             return True
-        if t == "number" and type(value) in (int, float) and not isinstance(value, bool):
+        if (
+            t == "number"
+            and type(value) in (int, float)
+            and not isinstance(value, bool)
+        ):
             return True
         if t == "null" and value is None:
             return True

--- a/apps/api/tests/test_input_schema_contract.py
+++ b/apps/api/tests/test_input_schema_contract.py
@@ -2,7 +2,9 @@
 
 import pytest
 from core.domain.input_schema_contract import (
+    ActionPayloadValidationError,
     InputSchemaValidationError,
+    validate_action_payload,
     validate_and_normalize_input_schema_json,
 )
 
@@ -46,3 +48,34 @@ def test_required_must_be_string_list():
         validate_and_normalize_input_schema_json(
             {"type": "object", "properties": {}, "required": [1]},
         )
+
+
+def test_validate_action_payload_accepts_matching_types():
+    schema = {
+        "type": "object",
+        "properties": {"q": {"type": "string"}, "n": {"type": "integer"}},
+        "required": ["q"],
+    }
+    assert validate_action_payload({"q": "hi", "n": 3}, schema) == {
+        "q": "hi",
+        "n": 3,
+    }
+
+
+def test_validate_action_payload_rejects_missing_required():
+    schema = {
+        "type": "object",
+        "properties": {"q": {"type": "string"}},
+        "required": ["q"],
+    }
+    with pytest.raises(ActionPayloadValidationError, match="missing required"):
+        validate_action_payload({}, schema)
+
+
+def test_validate_action_payload_rejects_wrong_type():
+    schema = {
+        "type": "object",
+        "properties": {"flag": {"type": "boolean"}},
+    }
+    with pytest.raises(ActionPayloadValidationError, match="invalid type"):
+        validate_action_payload({"flag": "yes"}, schema)

--- a/apps/api/tests/test_user_action_execute.py
+++ b/apps/api/tests/test_user_action_execute.py
@@ -115,9 +115,7 @@ def test_execute_requires_auth(client: TestClient):
     assert r.status_code == 401
 
 
-def test_execute_success_stub(
-    client: TestClient, tenant, db_session: Session
-):
+def test_execute_success_stub(client: TestClient, tenant, db_session: Session):
     tag = Tag(id=_id(), tenant_id=tenant.id, name="t")
     db_session.add(tag)
     db_session.flush()

--- a/apps/api/tests/test_user_action_execute.py
+++ b/apps/api/tests/test_user_action_execute.py
@@ -1,0 +1,375 @@
+"""
+POST /actions/{action_id}/execute: stub execution with permissions and payload validation.
+"""
+
+import uuid
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from auth.service import hash_password
+from config import JWT_ALGORITHM, JWT_SECRET
+from dependencies import get_db
+from domain.models import (
+    Action,
+    ActionTag,
+    Connector,
+    Group,
+    GroupActionFilter,
+    GroupUserFilter,
+    SavedFilter,
+    SavedFilterTag,
+    Tag,
+    Tenant,
+    User,
+    UserTag,
+)
+from fastapi.testclient import TestClient
+from jose import jwt
+from main import app
+from sqlalchemy.orm import Session
+
+
+def _id():
+    return uuid.uuid4().hex
+
+
+def _make_token(tenant_id: str, user_id: str, role: str) -> str:
+    payload = {
+        "sub": user_id,
+        "tenant_id": tenant_id,
+        "role": role,
+        "exp": datetime.now(UTC) + timedelta(hours=1),
+        "iat": datetime.now(UTC),
+    }
+    return jwt.encode(payload, JWT_SECRET, algorithm=JWT_ALGORITHM)
+
+
+def _auth_headers(tenant_id: str, user_id: str, role: str = "user"):
+    return {"Authorization": f"Bearer {_make_token(tenant_id, user_id, role)}"}
+
+
+def _execute_url(action_id: str) -> str:
+    return f"/actions/{action_id}/execute"
+
+
+@pytest.fixture
+def tenant(db_session: Session):
+    t = Tenant(id=_id(), name="Acme")
+    db_session.add(t)
+    db_session.flush()
+    return t
+
+
+@pytest.fixture
+def other_tenant(db_session: Session):
+    t = Tenant(id=_id(), name="OtherCo")
+    db_session.add(t)
+    db_session.flush()
+    return t
+
+
+@pytest.fixture
+def client(db_session: Session):
+    def override_get_db():
+        yield db_session
+
+    app.dependency_overrides[get_db] = override_get_db
+    with TestClient(app) as c:
+        yield c
+    app.dependency_overrides.pop(get_db, None)
+
+
+def _grant_user_action_via_group(
+    db_session: Session,
+    tenant: Tenant,
+    user: User,
+    action: Action,
+    user_tag: Tag,
+    action_tag: Tag,
+) -> None:
+    db_session.add(UserTag(user_id=user.id, tag_id=user_tag.id))
+    db_session.flush()
+
+    f_user = SavedFilter(
+        id=_id(), tenant_id=tenant.id, target_type="user", name="user-filter"
+    )
+    db_session.add(f_user)
+    db_session.add(SavedFilterTag(saved_filter_id=f_user.id, tag_id=user_tag.id))
+    f_act = SavedFilter(
+        id=_id(), tenant_id=tenant.id, target_type="action", name="action-filter"
+    )
+    db_session.add(f_act)
+    db_session.add(SavedFilterTag(saved_filter_id=f_act.id, tag_id=action_tag.id))
+    db_session.flush()
+
+    g = Group(id=_id(), tenant_id=tenant.id, name="G")
+    db_session.add(g)
+    db_session.flush()
+    db_session.add(GroupUserFilter(group_id=g.id, saved_filter_id=f_user.id))
+    db_session.add(GroupActionFilter(group_id=g.id, saved_filter_id=f_act.id))
+    db_session.flush()
+
+
+def test_execute_requires_auth(client: TestClient):
+    r = client.post(_execute_url(_id()), json={"payload": {}})
+    assert r.status_code == 401
+
+
+def test_execute_success_stub(
+    client: TestClient, tenant, db_session: Session
+):
+    tag = Tag(id=_id(), tenant_id=tenant.id, name="t")
+    db_session.add(tag)
+    db_session.flush()
+
+    user = User(
+        id=_id(),
+        tenant_id=tenant.id,
+        email="u@acme.com",
+        role="user",
+        password_hash=hash_password("x"),
+    )
+    db_session.add(user)
+    db_session.flush()
+
+    conn = Connector(
+        id=_id(),
+        tenant_id=tenant.id,
+        base_url="https://api.example.com",
+        auth_config={"Authorization": "Bearer SECRET"},
+    )
+    db_session.add(conn)
+    db_session.flush()
+
+    action = Action(
+        id=_id(),
+        tenant_id=tenant.id,
+        connector_id=conn.id,
+        method="POST",
+        path="/run",
+        name="run",
+        request_config={"body": {"hidden": True}},
+        input_schema_json={
+            "type": "object",
+            "properties": {"q": {"type": "string"}},
+            "required": ["q"],
+        },
+        input_schema_version="1",
+    )
+    db_session.add(action)
+    db_session.add(ActionTag(action_id=action.id, tag_id=tag.id))
+    db_session.flush()
+
+    _grant_user_action_via_group(db_session, tenant, user, action, tag, tag)
+
+    body = {"payload": {"q": "hello"}}
+    r = client.post(
+        _execute_url(action.id),
+        json=body,
+        headers=_auth_headers(tenant.id, user.id),
+    )
+    assert r.status_code == 200
+    data = r.json()
+    assert data["status"] == "ok"
+    assert "stub" in data["message"].lower()
+    assert data["received_payload"] == {"q": "hello"}
+    assert uuid.UUID(data["action_id"]) == uuid.UUID(action.id)
+    raw = r.text
+    assert "SECRET" not in raw
+    assert "hidden" not in raw
+
+
+def test_execute_forbidden_without_permission(
+    client: TestClient, tenant, db_session: Session
+):
+    tag_user = Tag(id=_id(), tenant_id=tenant.id, name="u")
+    tag_action = Tag(id=_id(), tenant_id=tenant.id, name="a")
+    db_session.add_all([tag_user, tag_action])
+    db_session.flush()
+
+    user = User(
+        id=_id(),
+        tenant_id=tenant.id,
+        email="u@acme.com",
+        role="user",
+        password_hash=hash_password("x"),
+    )
+    db_session.add(user)
+    db_session.add(UserTag(user_id=user.id, tag_id=tag_user.id))
+    db_session.flush()
+
+    conn = Connector(
+        id=_id(),
+        tenant_id=tenant.id,
+        base_url="https://api.example.com",
+    )
+    db_session.add(conn)
+    db_session.flush()
+
+    action = Action(
+        id=_id(),
+        tenant_id=tenant.id,
+        connector_id=conn.id,
+        method="GET",
+        path="/x",
+        name="x",
+        input_schema_json={"type": "object", "properties": {}},
+    )
+    db_session.add(action)
+    db_session.add(ActionTag(action_id=action.id, tag_id=tag_action.id))
+    db_session.flush()
+
+    r = client.post(
+        _execute_url(action.id),
+        json={"payload": {}},
+        headers=_auth_headers(tenant.id, user.id),
+    )
+    assert r.status_code == 403
+
+
+def test_execute_cross_tenant_blocked(
+    client: TestClient, tenant, other_tenant, db_session: Session
+):
+    tag = Tag(id=_id(), tenant_id=tenant.id, name="t")
+    db_session.add(tag)
+    db_session.flush()
+
+    user = User(
+        id=_id(),
+        tenant_id=tenant.id,
+        email="u@acme.com",
+        role="user",
+        password_hash=hash_password("x"),
+    )
+    db_session.add(user)
+    db_session.flush()
+
+    conn_other = Connector(
+        id=_id(),
+        tenant_id=other_tenant.id,
+        base_url="https://other.com",
+    )
+    db_session.add(conn_other)
+    db_session.flush()
+
+    other_action = Action(
+        id=_id(),
+        tenant_id=other_tenant.id,
+        connector_id=conn_other.id,
+        method="GET",
+        path="/",
+        name="other",
+        input_schema_json={"type": "object", "properties": {}},
+    )
+    db_session.add(other_action)
+    db_session.flush()
+
+    r = client.post(
+        _execute_url(other_action.id),
+        json={"payload": {}},
+        headers=_auth_headers(tenant.id, user.id),
+    )
+    assert r.status_code == 404
+
+
+def test_execute_invalid_payload_missing_required(
+    client: TestClient, tenant, db_session: Session
+):
+    tag = Tag(id=_id(), tenant_id=tenant.id, name="t")
+    db_session.add(tag)
+    db_session.flush()
+
+    user = User(
+        id=_id(),
+        tenant_id=tenant.id,
+        email="u@acme.com",
+        role="user",
+        password_hash=hash_password("x"),
+    )
+    db_session.add(user)
+    db_session.flush()
+
+    conn = Connector(
+        id=_id(),
+        tenant_id=tenant.id,
+        base_url="https://api.example.com",
+    )
+    db_session.add(conn)
+    db_session.flush()
+
+    action = Action(
+        id=_id(),
+        tenant_id=tenant.id,
+        connector_id=conn.id,
+        method="POST",
+        path="/run",
+        name="run",
+        input_schema_json={
+            "type": "object",
+            "properties": {"q": {"type": "string"}},
+            "required": ["q"],
+        },
+    )
+    db_session.add(action)
+    db_session.add(ActionTag(action_id=action.id, tag_id=tag.id))
+    db_session.flush()
+
+    _grant_user_action_via_group(db_session, tenant, user, action, tag, tag)
+
+    r = client.post(
+        _execute_url(action.id),
+        json={"payload": {}},
+        headers=_auth_headers(tenant.id, user.id),
+    )
+    assert r.status_code == 422
+
+
+def test_execute_invalid_payload_wrong_type(
+    client: TestClient, tenant, db_session: Session
+):
+    tag = Tag(id=_id(), tenant_id=tenant.id, name="t")
+    db_session.add(tag)
+    db_session.flush()
+
+    user = User(
+        id=_id(),
+        tenant_id=tenant.id,
+        email="u@acme.com",
+        role="user",
+        password_hash=hash_password("x"),
+    )
+    db_session.add(user)
+    db_session.flush()
+
+    conn = Connector(
+        id=_id(),
+        tenant_id=tenant.id,
+        base_url="https://api.example.com",
+    )
+    db_session.add(conn)
+    db_session.flush()
+
+    action = Action(
+        id=_id(),
+        tenant_id=tenant.id,
+        connector_id=conn.id,
+        method="POST",
+        path="/run",
+        name="run",
+        input_schema_json={
+            "type": "object",
+            "properties": {"count": {"type": "integer"}},
+        },
+    )
+    db_session.add(action)
+    db_session.add(ActionTag(action_id=action.id, tag_id=tag.id))
+    db_session.flush()
+
+    _grant_user_action_via_group(db_session, tenant, user, action, tag, tag)
+
+    r = client.post(
+        _execute_url(action.id),
+        json={"payload": {"count": "not-a-number"}},
+        headers=_auth_headers(tenant.id, user.id),
+    )
+    assert r.status_code == 422


### PR DESCRIPTION
## Enlaces
- Jira: CRYPT-9
- Engram: tasks/CRYPT-9

## Resumen
- POST `/actions/{id}/execute` con comprobación de permisos por tenant y grupos
- Validación de payload frente al contrato `input_schema` de la acción
- Casos de prueba para ejecución y contrato de esquema

## Testing
- [x] `pytest` en `apps/api/tests/test_user_action_execute.py` y `test_input_schema_contract.py`
