### PR TITLE
feat: Sprint 1 — preferences API, profile UX, E2E smoke (CRYPT-11/47/12)

### DIFF
--- a/apps/api/adapters/driven/persistence/models.py
+++ b/apps/api/adapters/driven/persistence/models.py
@@ -153,6 +153,24 @@ class DocumentTagOrm(Base):
     tag_id = Column(UUID(as_uuid=False), ForeignKey("tags.id"), primary_key=True)
 
 
+class UserPreferencesOrm(Base):
+    __tablename__ = "user_preferences"
+    id = Column(UUID(as_uuid=False), primary_key=True, default=lambda: uuid.uuid4().hex)
+    tenant_id = Column(
+        UUID(as_uuid=False), ForeignKey("tenants.id"), nullable=False, index=True
+    )
+    user_id = Column(UUID(as_uuid=False), ForeignKey("users.id"), nullable=False)
+    theme = Column(String(32), nullable=False, default="system")
+    language = Column(String(32), nullable=False, default="es")
+    table_density = Column(String(32), nullable=False, default="comfortable")
+    metadata_ = Column("metadata", JSONB, nullable=True)
+    __table_args__ = (
+        UniqueConstraint(
+            "tenant_id", "user_id", name="uq_user_preferences_tenant_user"
+        ),
+    )
+
+
 # Transitional semantic aliases for Sprint 02.5 task-08a.
 # They intentionally point to the existing tables/models to keep
 # backward compatibility while introducing clearer domain naming.

--- a/apps/api/adapters/driven/persistence/user_preferences_repository.py
+++ b/apps/api/adapters/driven/persistence/user_preferences_repository.py
@@ -1,0 +1,78 @@
+"""UserPreferences repository implementation."""
+
+from core.domain.models import UserPreferences
+from core.ports.user_preferences_repository import UserPreferencesRepository
+from sqlalchemy.orm import Session
+
+from adapters.driven.persistence.models import UserPreferencesOrm
+from adapters.driven.persistence.uuid_utils import eq_uuid, normalize_uuid, parse_uuid
+
+
+def _orm_to_domain(orm: UserPreferencesOrm) -> UserPreferences:
+    meta = orm.metadata_
+    return UserPreferences(
+        user_id=str(orm.user_id),
+        tenant_id=str(orm.tenant_id),
+        theme=orm.theme,
+        language=orm.language,
+        table_density=orm.table_density,
+        metadata=dict(meta) if meta is not None else {},
+    )
+
+
+class UserPreferencesRepositoryImpl(UserPreferencesRepository):
+    def __init__(self, session: Session) -> None:
+        self._session = session
+
+    def _query_for_user(self, tenant_id: str, user_id: str):
+        uid = parse_uuid(user_id)
+        tid = parse_uuid(tenant_id)
+        if uid is None or tid is None:
+            return None
+        uid_hex = uid.hex
+        uid_canonical = str(uid)
+        tid_hex = tid.hex
+        tid_canonical = str(tid)
+        return self._session.query(UserPreferencesOrm).filter(
+            UserPreferencesOrm.tenant_id.in_([tid_hex, tid_canonical]),
+            UserPreferencesOrm.user_id.in_([uid_hex, uid_canonical]),
+        )
+
+    def get_by_user(self, tenant_id: str, user_id: str) -> UserPreferences | None:
+        q = self._query_for_user(tenant_id, user_id)
+        if q is None:
+            return None
+        orm = q.first()
+        if orm is None:
+            return None
+        if not eq_uuid(str(orm.tenant_id), tenant_id):
+            return None
+        return _orm_to_domain(orm)
+
+    def upsert(self, preferences: UserPreferences) -> UserPreferences:
+        uid = parse_uuid(preferences.user_id)
+        if uid is None:
+            return preferences
+        uid_hex = uid.hex
+        q = self._query_for_user(preferences.tenant_id, preferences.user_id)
+        orm = q.first() if q is not None else None
+        tid = normalize_uuid(preferences.tenant_id) or preferences.tenant_id
+        meta = preferences.metadata if preferences.metadata is not None else {}
+        if orm is None:
+            orm = UserPreferencesOrm(
+                tenant_id=tid,
+                user_id=uid_hex,
+                theme=preferences.theme,
+                language=preferences.language,
+                table_density=preferences.table_density,
+                metadata_=meta,
+            )
+            self._session.add(orm)
+        else:
+            orm.theme = preferences.theme
+            orm.language = preferences.language
+            orm.table_density = preferences.table_density
+            orm.metadata_ = meta
+        self._session.flush()
+        self._session.refresh(orm)
+        return _orm_to_domain(orm)

--- a/apps/api/adapters/driving/http/me/__init__.py
+++ b/apps/api/adapters/driving/http/me/__init__.py
@@ -1,0 +1,1 @@
+"""Current-user HTTP routes."""

--- a/apps/api/adapters/driving/http/me/routes.py
+++ b/apps/api/adapters/driving/http/me/routes.py
@@ -1,0 +1,49 @@
+"""Current-user routes: preferences."""
+
+from typing import Annotated
+
+from core.application import user_preferences as prefs_use_cases
+from dependencies import CurrentUser, get_current_user, get_db
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+
+from adapters.driven.persistence.user_preferences_repository import (
+    UserPreferencesRepositoryImpl,
+)
+from adapters.driving.schemas.user_preferences import (
+    UserPreferencesPatchBody,
+    preferences_to_response,
+)
+
+router = APIRouter(prefix="/me", tags=["me"])
+
+
+@router.get("/preferences")
+def get_my_preferences(
+    current_user: Annotated[CurrentUser, Depends(get_current_user)],
+    db: Annotated[Session, Depends(get_db)],
+):
+    repo = UserPreferencesRepositoryImpl(db)
+    prefs = prefs_use_cases.get_preferences(
+        current_user.tenant_id, current_user.sub, repo
+    )
+    return preferences_to_response(prefs)
+
+
+@router.patch("/preferences")
+def patch_my_preferences(
+    body: UserPreferencesPatchBody,
+    current_user: Annotated[CurrentUser, Depends(get_current_user)],
+    db: Annotated[Session, Depends(get_db)],
+):
+    repo = UserPreferencesRepositoryImpl(db)
+    prefs = prefs_use_cases.update_preferences(
+        current_user.tenant_id,
+        current_user.sub,
+        theme=body.theme.value if body.theme is not None else None,
+        language=body.language,
+        table_density=body.table_density,
+        metadata=body.metadata,
+        repo=repo,
+    )
+    return preferences_to_response(prefs)

--- a/apps/api/adapters/driving/schemas/user_preferences.py
+++ b/apps/api/adapters/driving/schemas/user_preferences.py
@@ -1,0 +1,44 @@
+"""Request/response schemas for /me/preferences."""
+
+from typing import Any, Literal
+
+from core.domain.models import UserPreferences
+from pydantic import BaseModel, Field, field_validator
+from shared_contract import UserTheme
+
+TableDensity = Literal["comfortable", "compact"]
+
+
+class UserPreferencesResponse(BaseModel):
+    theme: UserTheme
+    language: str
+    table_density: TableDensity
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+class UserPreferencesPatchBody(BaseModel):
+    theme: UserTheme | None = None
+    language: str | None = Field(default=None, min_length=2, max_length=16)
+    table_density: TableDensity | None = None
+    metadata: dict[str, Any] | None = None
+
+    @field_validator("language")
+    @classmethod
+    def language_reasonable(cls, value: str | None) -> str | None:
+        if value is None:
+            return value
+        stripped = value.strip()
+        if not stripped:
+            raise ValueError("language must not be empty")
+        if not all(ch.isalpha() or ch == "-" for ch in stripped):
+            raise ValueError("language must contain only letters and hyphens")
+        return stripped
+
+
+def preferences_to_response(prefs: UserPreferences) -> dict:
+    return UserPreferencesResponse(
+        theme=prefs.theme,
+        language=prefs.language,
+        table_density=prefs.table_density,
+        metadata=prefs.metadata or {},
+    ).model_dump()

--- a/apps/api/core/application/user_preferences.py
+++ b/apps/api/core/application/user_preferences.py
@@ -1,0 +1,58 @@
+"""Use cases for current-user preferences."""
+
+from shared_contract import USER_THEME_SYSTEM
+
+from core.domain.models import UserPreferences
+from core.ports.user_preferences_repository import UserPreferencesRepository
+
+DEFAULT_LANGUAGE = "es"
+DEFAULT_TABLE_DENSITY = "comfortable"
+DEFAULT_METADATA: dict = {}
+
+
+def _defaults(tenant_id: str, user_id: str) -> UserPreferences:
+    return UserPreferences(
+        tenant_id=tenant_id,
+        user_id=user_id,
+        theme=USER_THEME_SYSTEM,
+        language=DEFAULT_LANGUAGE,
+        table_density=DEFAULT_TABLE_DENSITY,
+        metadata=dict(DEFAULT_METADATA),
+    )
+
+
+def get_preferences(
+    tenant_id: str,
+    user_id: str,
+    repo: UserPreferencesRepository,
+) -> UserPreferences:
+    stored = repo.get_by_user(tenant_id, user_id)
+    if stored is None:
+        return _defaults(tenant_id, user_id)
+    return stored
+
+
+def update_preferences(
+    tenant_id: str,
+    user_id: str,
+    *,
+    theme: str | None = None,
+    language: str | None = None,
+    table_density: str | None = None,
+    metadata: dict | None = None,
+    repo: UserPreferencesRepository,
+) -> UserPreferences:
+    current = get_preferences(tenant_id, user_id, repo)
+    updated = UserPreferences(
+        tenant_id=tenant_id,
+        user_id=user_id,
+        theme=theme if theme is not None else current.theme,
+        language=language if language is not None else current.language,
+        table_density=(
+            table_density if table_density is not None else current.table_density
+        ),
+        metadata=(
+            dict(metadata) if metadata is not None else dict(current.metadata or {})
+        ),
+    )
+    return repo.upsert(updated)

--- a/apps/api/core/domain/models.py
+++ b/apps/api/core/domain/models.py
@@ -90,3 +90,13 @@ class Document:
     status: str  # queued | processing | indexed | error
     file_path: str | None = None
     id: str | None = None
+
+
+@dataclass
+class UserPreferences:
+    tenant_id: str
+    user_id: str
+    theme: str = "system"
+    language: str = "es"
+    table_density: str = "comfortable"
+    metadata: dict[str, Any] | None = None

--- a/apps/api/core/ports/user_preferences_repository.py
+++ b/apps/api/core/ports/user_preferences_repository.py
@@ -1,0 +1,11 @@
+"""Port for UserPreferences persistence."""
+
+from typing import Protocol
+
+from core.domain.models import UserPreferences
+
+
+class UserPreferencesRepository(Protocol):
+    def get_by_user(self, tenant_id: str, user_id: str) -> UserPreferences | None: ...
+
+    def upsert(self, preferences: UserPreferences) -> UserPreferences: ...

--- a/apps/api/domain/models.py
+++ b/apps/api/domain/models.py
@@ -21,6 +21,7 @@ from adapters.driven.persistence.models import (  # type: ignore[F401]
     TagOrm,
     TenantOrm,
     UserOrm,
+    UserPreferencesOrm,
     UserTagOrm,
 )
 
@@ -41,6 +42,7 @@ SavedFilterTag = SavedFilterTagOrm
 Tag = TagOrm
 Tenant = TenantOrm
 User = UserOrm
+UserPreferences = UserPreferencesOrm
 UserTag = UserTagOrm
 
 __all__ = [
@@ -61,5 +63,6 @@ __all__ = [
     "Tag",
     "Tenant",
     "User",
+    "UserPreferences",
     "UserTag",
 ]

--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -4,6 +4,7 @@ from adapters.driven.persistence.dev_seed import ensure_dev_admin
 from adapters.driving.http.actions.routes import router as actions_router
 from adapters.driving.http.admin.routes import router as admin_router
 from adapters.driving.http.auth.routes import router as auth_router
+from adapters.driving.http.me.routes import router as me_router
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
@@ -27,6 +28,7 @@ app.add_middleware(
 )
 app.include_router(auth_router)
 app.include_router(actions_router)
+app.include_router(me_router)
 app.include_router(admin_router)
 
 

--- a/apps/api/migrations/versions/005_user_preferences.py
+++ b/apps/api/migrations/versions/005_user_preferences.py
@@ -1,0 +1,62 @@
+"""user_preferences table
+
+Revision ID: 005
+Revises: 004
+Create Date: User preferences (theme, language, table_density, metadata)
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision: str = "005"
+down_revision: str | Sequence[str] | None = "004"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "user_preferences",
+        sa.Column("id", postgresql.UUID(as_uuid=False), primary_key=True),
+        sa.Column(
+            "tenant_id",
+            postgresql.UUID(as_uuid=False),
+            sa.ForeignKey("tenants.id"),
+            nullable=False,
+        ),
+        sa.Column(
+            "user_id",
+            postgresql.UUID(as_uuid=False),
+            sa.ForeignKey("users.id"),
+            nullable=False,
+        ),
+        sa.Column("theme", sa.String(32), nullable=False, server_default="system"),
+        sa.Column("language", sa.String(32), nullable=False, server_default="es"),
+        sa.Column(
+            "table_density",
+            sa.String(32),
+            nullable=False,
+            server_default="comfortable",
+        ),
+        sa.Column("metadata", postgresql.JSONB(), nullable=True),
+    )
+    op.create_index(
+        "ix_user_preferences_tenant_id", "user_preferences", ["tenant_id"], unique=False
+    )
+    op.create_unique_constraint(
+        "uq_user_preferences_tenant_user",
+        "user_preferences",
+        ["tenant_id", "user_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(
+        "uq_user_preferences_tenant_user", "user_preferences", type_="unique"
+    )
+    op.drop_index("ix_user_preferences_tenant_id", table_name="user_preferences")
+    op.drop_table("user_preferences")

--- a/apps/api/tests/test_me_preferences.py
+++ b/apps/api/tests/test_me_preferences.py
@@ -1,0 +1,189 @@
+"""
+GET/PATCH /me/preferences: preferencias de usuario autenticado (tenant-scoped).
+"""
+
+import uuid
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from auth.service import hash_password
+from config import JWT_ALGORITHM, JWT_SECRET
+from dependencies import get_db
+from domain.models import Tenant, User
+from fastapi.testclient import TestClient
+from jose import jwt
+from main import app
+from sqlalchemy.orm import Session
+
+
+def _id():
+    return uuid.uuid4().hex
+
+
+def _make_token(tenant_id: str, user_id: str, role: str = "user") -> str:
+    payload = {
+        "sub": user_id,
+        "tenant_id": tenant_id,
+        "role": role,
+        "exp": datetime.now(UTC) + timedelta(hours=1),
+        "iat": datetime.now(UTC),
+    }
+    return jwt.encode(payload, JWT_SECRET, algorithm=JWT_ALGORITHM)
+
+
+def _auth_headers(tenant_id: str, user_id: str, role: str = "user"):
+    return {"Authorization": f"Bearer {_make_token(tenant_id, user_id, role)}"}
+
+
+@pytest.fixture
+def tenant(db_session: Session):
+    t = Tenant(id=_id(), name="Acme")
+    db_session.add(t)
+    db_session.flush()
+    return t
+
+
+@pytest.fixture
+def other_tenant(db_session: Session):
+    t = Tenant(id=_id(), name="OtherCo")
+    db_session.add(t)
+    db_session.flush()
+    return t
+
+
+@pytest.fixture
+def user(db_session: Session, tenant):
+    u = User(
+        id=_id(),
+        tenant_id=tenant.id,
+        email="u@acme.com",
+        role="user",
+        password_hash=hash_password("x"),
+    )
+    db_session.add(u)
+    db_session.flush()
+    return u
+
+
+@pytest.fixture
+def other_user(db_session: Session, other_tenant):
+    u = User(
+        id=_id(),
+        tenant_id=other_tenant.id,
+        email="u@other.com",
+        role="user",
+        password_hash=hash_password("x"),
+    )
+    db_session.add(u)
+    db_session.flush()
+    return u
+
+
+@pytest.fixture
+def client(db_session: Session):
+    def override_get_db():
+        yield db_session
+
+    app.dependency_overrides[get_db] = override_get_db
+    with TestClient(app) as c:
+        yield c
+    app.dependency_overrides.pop(get_db, None)
+
+
+def test_get_preferences_requires_auth(client: TestClient):
+    r = client.get("/me/preferences")
+    assert r.status_code == 401
+
+
+def test_patch_preferences_requires_auth(client: TestClient):
+    r = client.patch("/me/preferences", json={"theme": "dark"})
+    assert r.status_code == 401
+
+
+def test_get_returns_defaults_when_no_row(client: TestClient, tenant, user):
+    r = client.get("/me/preferences", headers=_auth_headers(tenant.id, user.id))
+    assert r.status_code == 200
+    assert r.json() == {
+        "theme": "system",
+        "language": "es",
+        "table_density": "comfortable",
+        "metadata": {},
+    }
+
+
+def test_patch_partial_update_persists_and_get_reflects(
+    client: TestClient, tenant, user
+):
+    headers = _auth_headers(tenant.id, user.id)
+    r = client.patch("/me/preferences", headers=headers, json={"theme": "dark"})
+    assert r.status_code == 200
+    body = r.json()
+    assert body["theme"] == "dark"
+    assert body["language"] == "es"
+    assert body["table_density"] == "comfortable"
+    assert body["metadata"] == {}
+
+    r2 = client.get("/me/preferences", headers=headers)
+    assert r2.status_code == 200
+    assert r2.json()["theme"] == "dark"
+
+
+def test_patch_updates_multiple_fields(client: TestClient, tenant, user):
+    headers = _auth_headers(tenant.id, user.id)
+    r = client.patch(
+        "/me/preferences",
+        headers=headers,
+        json={
+            "language": "en",
+            "table_density": "compact",
+            "metadata": {"sidebar": "collapsed"},
+        },
+    )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["theme"] == "system"
+    assert body["language"] == "en"
+    assert body["table_density"] == "compact"
+    assert body["metadata"] == {"sidebar": "collapsed"}
+
+
+def test_patch_invalid_theme_returns_422(client: TestClient, tenant, user):
+    r = client.patch(
+        "/me/preferences",
+        headers=_auth_headers(tenant.id, user.id),
+        json={"theme": "neon"},
+    )
+    assert r.status_code == 422
+
+
+def test_patch_invalid_table_density_returns_422(client: TestClient, tenant, user):
+    r = client.patch(
+        "/me/preferences",
+        headers=_auth_headers(tenant.id, user.id),
+        json={"table_density": "spacious"},
+    )
+    assert r.status_code == 422
+
+
+def test_patch_invalid_language_returns_422(client: TestClient, tenant, user):
+    r = client.patch(
+        "/me/preferences",
+        headers=_auth_headers(tenant.id, user.id),
+        json={"language": ""},
+    )
+    assert r.status_code == 422
+
+
+def test_preferences_scoped_per_user(
+    client: TestClient, tenant, user, other_user, other_tenant
+):
+    headers_a = _auth_headers(tenant.id, user.id)
+    headers_b = _auth_headers(other_tenant.id, other_user.id)
+
+    client.patch("/me/preferences", headers=headers_a, json={"theme": "light"})
+    client.patch("/me/preferences", headers=headers_b, json={"theme": "dark"})
+
+    r_a = client.get("/me/preferences", headers=headers_a)
+    r_b = client.get("/me/preferences", headers=headers_b)
+    assert r_a.json()["theme"] == "light"
+    assert r_b.json()["theme"] == "dark"

--- a/apps/web/e2e/README.md
+++ b/apps/web/e2e/README.md
@@ -1,0 +1,17 @@
+# Smoke E2E (Playwright)
+
+Requiere stack local en marcha (API en `:8000`, web en `:3000`) y seed dev (`admin@dev.local` / `admin`).
+
+```bash
+# Desde la raíz del monorepo
+docker compose -f infra/docker-compose.dev.yml up -d
+
+# Migraciones (si la tabla user_preferences no existe)
+docker compose -f infra/docker-compose.dev.yml exec api alembic upgrade head
+
+# E2E (reutiliza el servidor en :3000 si ya está levantado)
+cd apps/web
+npm install
+npx playwright install chromium
+PLAYWRIGHT_SKIP_WEB_SERVER=1 npm run test:e2e
+```

--- a/apps/web/e2e/smoke.spec.js
+++ b/apps/web/e2e/smoke.spec.js
@@ -1,0 +1,32 @@
+import { test, expect } from "@playwright/test";
+
+const DEV_TENANT = "00000000-0000-4000-8000-000000000001";
+const DEV_EMAIL = "admin@dev.local";
+const DEV_PASSWORD = "admin";
+
+async function devLogin(page) {
+  await page.goto("/login");
+  await page.getByLabel("Tenant ID").fill(DEV_TENANT);
+  await page.getByLabel("Email").fill(DEV_EMAIL);
+  await page.getByLabel("Password").fill(DEV_PASSWORD);
+  await page.getByRole("button", { name: "Entrar" }).click();
+  await expect(page).toHaveURL(/\/admin\/users/);
+}
+
+test("admin login reaches users workspace", async ({ page }) => {
+  await devLogin(page);
+  await expect(page.getByRole("heading", { name: "Usuarios" })).toBeVisible();
+});
+
+test("admin navigates to connectors", async ({ page }) => {
+  await devLogin(page);
+  await page.getByRole("link", { name: /Conectores/i }).click();
+  await expect(page).toHaveURL(/\/admin\/connectors/);
+});
+
+test("chat assistant page loads after login", async ({ page }) => {
+  await devLogin(page);
+  await page.getByRole("link", { name: /Chat/i }).click();
+  await expect(page).toHaveURL(/\/chat/);
+  await expect(page.getByRole("heading", { name: "Asistente" })).toBeVisible();
+});

--- a/apps/web/eslint.config.js
+++ b/apps/web/eslint.config.js
@@ -14,7 +14,7 @@ export default [
     ignores: ["dist", "node_modules", "coverage"],
   },
   {
-    files: ["eslint.config.js", "vite.config.js"],
+    files: ["eslint.config.js", "vite.config.js", "playwright.config.js"],
     languageOptions: {
       globals: globals.node,
       ecmaVersion: "latest",

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -15,6 +15,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.17.0",
+        "@playwright/test": "^1.52.0",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
         "@vitejs/plugin-react": "^4.3.4",
@@ -1263,6 +1264,22 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rolldown/pluginutils": {
@@ -4673,6 +4690,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -9,6 +9,8 @@
     "preview": "vite preview",
     "test": "vitest run",
     "test:watch": "vitest",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui",
     "format": "prettier --write \"src/**/*.{js,jsx,css}\" \"../../packages/shared/src/**/*.js\"",
     "format:check": "prettier --check \"src/**/*.{js,jsx,css}\" \"../../packages/shared/src/**/*.js\"",
     "lint": "eslint ."
@@ -30,6 +32,7 @@
     "eslint-plugin-react-hooks": "^5.1.0",
     "globals": "^15.14.0",
     "jsdom": "^28.1.0",
+    "@playwright/test": "^1.52.0",
     "prettier": "^3.4.2",
     "vite": "^6.0.7",
     "vitest": "^4.1.0"

--- a/apps/web/playwright.config.js
+++ b/apps/web/playwright.config.js
@@ -1,0 +1,20 @@
+import { defineConfig } from "@playwright/test";
+
+/** Smoke E2E against local dev stack (API + web on docker compose). */
+export default defineConfig({
+  testDir: "./e2e",
+  timeout: 60_000,
+  retries: 0,
+  use: {
+    baseURL: process.env.PLAYWRIGHT_BASE_URL || "http://localhost:3000",
+    trace: "on-first-retry",
+  },
+  webServer: process.env.PLAYWRIGHT_SKIP_WEB_SERVER
+    ? undefined
+    : {
+        command: "npm run dev",
+        url: "http://localhost:3000",
+        reuseExistingServer: true,
+        timeout: 120_000,
+      },
+});

--- a/apps/web/src/modules/admin/ProfileMenu.jsx
+++ b/apps/web/src/modules/admin/ProfileMenu.jsx
@@ -1,5 +1,6 @@
 import { useNavigate } from "react-router-dom";
 import { useAuth } from "../../app/AuthProvider";
+import { PreferencesPanel } from "../preferences/PreferencesPanel";
 
 export function ProfileMenu() {
   const { user, logout } = useAuth();
@@ -17,8 +18,10 @@ export function ProfileMenu() {
         </span>
       </summary>
       <div className="profile-popover">
+        <PreferencesPanel />
         <button
           type="button"
+          className="profile-logout"
           onClick={async () => {
             await logout();
             navigate("/login");

--- a/apps/web/src/modules/chat/ChatPage.jsx
+++ b/apps/web/src/modules/chat/ChatPage.jsx
@@ -3,7 +3,7 @@ import { useNavigate } from "react-router-dom";
 import { useAuth } from "../../app/AuthProvider";
 import { api } from "../../shared/apiClient";
 import { ApiErrorBanner, EmptyState, LoadingBlock } from "../../shared/ui";
-import { PreferencesPanel } from "../preferences/PreferencesPanel";
+import { ProfileMenu } from "../admin/ProfileMenu";
 import { ActionExecutionResult } from "./ActionExecutionResult";
 import { AllowedActionsList } from "./AllowedActionsList";
 import {
@@ -20,7 +20,7 @@ export function ChatPage() {
   const [result, setResult] = useState(null);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState(null);
-  const { user, isAdmin, logout } = useAuth();
+  const { user, isAdmin } = useAuth();
   const navigate = useNavigate();
 
   const loadActions = useCallback(async () => {
@@ -90,21 +90,13 @@ export function ChatPage() {
               Usuario: {user?.sub} ({user?.role})
             </small>
           </div>
-          <div className="row">
+          <div className="row page-header-actions">
             {isAdmin ? (
               <button type="button" onClick={() => navigate("/admin/users")}>
                 Ir a admin
               </button>
             ) : null}
-            <button
-              type="button"
-              onClick={async () => {
-                await logout();
-                navigate("/login");
-              }}
-            >
-              Logout
-            </button>
+            <ProfileMenu />
           </div>
         </div>
         <ApiErrorBanner error={error} />
@@ -159,8 +151,6 @@ export function ChatPage() {
           </section>
         </div>
       ) : null}
-
-      <PreferencesPanel />
     </div>
   );
 }

--- a/apps/web/src/modules/preferences/PreferencesPanel.jsx
+++ b/apps/web/src/modules/preferences/PreferencesPanel.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { api } from "../../shared/apiClient";
 import { ApiErrorBanner, LoadingBlock } from "../../shared/ui";
+import { applyTheme } from "./applyTheme";
 
 const DEFAULTS = {
   theme: "system",
@@ -22,12 +23,14 @@ export function PreferencesPanel() {
       setError(null);
       try {
         const data = (await api.get("/me/preferences")) || {};
+        const theme = data.theme || "system";
         setForm({
-          theme: data.theme || "system",
+          theme,
           language: data.language || "es",
           table_density: data.table_density || "comfortable",
           metadata: JSON.stringify(data.metadata || {}, null, 2),
         });
+        applyTheme(theme);
       } catch (nextError) {
         setError(nextError);
       } finally {
@@ -49,6 +52,7 @@ export function PreferencesPanel() {
         table_density: form.table_density,
         metadata: JSON.parse(form.metadata || "{}"),
       });
+      applyTheme(form.theme);
       setOk("Preferencias guardadas.");
     } catch (nextError) {
       setError(nextError);
@@ -58,8 +62,8 @@ export function PreferencesPanel() {
   }
 
   return (
-    <section className="panel">
-      <h2>Preferencias</h2>
+    <section className="preferences-panel">
+      <h2 className="preferences-panel-title">Preferencias</h2>
       {loading ? <LoadingBlock /> : null}
       <ApiErrorBanner error={error} />
       {ok ? <div className="badge success">{ok}</div> : null}
@@ -69,9 +73,11 @@ export function PreferencesPanel() {
             Theme
             <select
               value={form.theme}
-              onChange={(event) =>
-                setForm((prev) => ({ ...prev, theme: event.target.value }))
-              }
+              onChange={(event) => {
+                const theme = event.target.value;
+                setForm((prev) => ({ ...prev, theme }));
+                applyTheme(theme);
+              }}
             >
               <option value="system">system</option>
               <option value="light">light</option>

--- a/apps/web/src/modules/preferences/applyTheme.js
+++ b/apps/web/src/modules/preferences/applyTheme.js
@@ -1,0 +1,13 @@
+/** Apply theme to document root (system = no data-theme, uses CSS default). */
+export function applyTheme(theme) {
+  const root = document.documentElement;
+  if (theme === "dark") {
+    root.setAttribute("data-theme", "dark");
+    return;
+  }
+  if (theme === "light") {
+    root.setAttribute("data-theme", "light");
+    return;
+  }
+  root.removeAttribute("data-theme");
+}

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -716,3 +716,56 @@ button.danger {
   background: #fbfcff;
   padding: 12px;
 }
+
+:root[data-theme="dark"] {
+  color-scheme: dark;
+}
+
+:root[data-theme="dark"] body {
+  background: #12151c;
+  color: #e8ecf4;
+}
+
+:root[data-theme="dark"] .panel,
+:root[data-theme="dark"] .profile-popover {
+  background: #1a1f2a;
+  border-color: #2d3548;
+  color: #e8ecf4;
+}
+
+:root[data-theme="dark"] input,
+:root[data-theme="dark"] select,
+:root[data-theme="dark"] textarea {
+  background: #0f131a;
+  border-color: #3a4458;
+  color: #e8ecf4;
+}
+
+.profile-popover {
+  min-width: 280px;
+  max-width: 360px;
+  z-index: 20;
+}
+
+.profile-popover .preferences-panel {
+  margin: 0 0 8px;
+  padding: 0;
+  border: none;
+  background: transparent;
+  box-shadow: none;
+}
+
+.profile-popover .preferences-panel-title {
+  margin: 0 0 8px;
+  font-size: 0.95rem;
+}
+
+.profile-popover .profile-logout {
+  width: 100%;
+  margin-top: 4px;
+}
+
+.page-header-actions {
+  align-items: center;
+  gap: 8px;
+}

--- a/apps/web/vite.config.js
+++ b/apps/web/vite.config.js
@@ -11,5 +11,6 @@ export default defineConfig({
     environment: "jsdom",
     setupFiles: "./src/test/setupTests.js",
     globals: true,
+    exclude: ["e2e/**", "node_modules/**"],
   },
 });


### PR DESCRIPTION
## Summary
- **CRYPT-11**: GET/PATCH `/me/preferences` with migration and 9 API tests.
- **CRYPT-47**: Preferences in ProfileMenu (admin + chat); theme on document; no duplicate panel in chat.
- **CRYPT-12**: Playwright smoke (admin login, connectors nav, chat). See `apps/web/e2e/README.md`.

## Jira
CRYPT-11, CRYPT-47, CRYPT-12

## Test plan
- [x] pytest `test_me_preferences.py`
- [x] `npm run test` (Vitest)
- [ ] `PLAYWRIGHT_SKIP_WEB_SERVER=1 npm run test:e2e` with stack up
- [ ] Manual: profile preferences + theme; chat execute stub

## Migration
```bash
docker compose -f infra/docker-compose.dev.yml exec api alembic upgrade head
```
